### PR TITLE
Add support for UDP and passing additional fields

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,6 @@
 {
   "extends": "eslint-config-hapi",
   "rules": {
-    "spaced-comment": "off",
-    "hapi/hapi-scope-start": "off",
-    "indent": ["error", 4],
-    "space-before-function-paren": 0,
-    "semi": "off",
-    "padded-blocks": "off",
-    "key-spacing": "off",
-    "array-bracket-spacing": "off",
-    "brace-style": "off"
+    "hapi/hapi-scope-start": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "extends": "eslint-config-hapi",
+  "rules": {
+    "spaced-comment": "off",
+    "hapi/hapi-scope-start": "off",
+    "indent": ["error", 4],
+    "space-before-function-paren": 0,
+    "semi": "off",
+    "padded-blocks": "off",
+    "key-spacing": "off",
+    "array-bracket-spacing": "off",
+    "brace-style": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/*
+
+.idea
+.idea/*
+
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # good-influx
 
-InfluxDB broadcasting for Good process monitor, based on [good-http](https://github.com/hapijs/good-http).
+[InfluxDB](https://docs.influxdata.com/) broadcasting for Good process monitor, based on [good-http](https://github.com/hapijs/good-http).
 
 ![Current Version](https://img.shields.io/npm/v/good-influx.svg)
 
+`Good Influx` will format your Good data according to the [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v1.1/write_protocols/line_protocol_tutorial/).
 
 ## Usage
 
-`good-influx` is a write stream use to send event to remote endpoints in batches. It makes a "POST" request with a plain-text payload to the supplied `endpoint`. It will make a final "POST" request to the endpoint to flush the rest of the data on "finish".
+`good-influx` is a write stream used to send events to InfluxDB endpoints in batches. It makes a "POST" request with a plain-text payload to the supplied `endpoint`. It will make a final "POST" request to the endpoint to flush the rest of the data on "finish".
 
 ### Example
 
@@ -29,7 +30,10 @@ const options = {
         }, {
             module: 'good-influx',
             args: ['http://localhost:8086/write?db=good', {
-            	threshold: 10
+                threshold: 10,
+                metadata: {
+                    serviceName: 'SuperAwesomeService'
+                }
         	}]
         }]
     }
@@ -57,11 +61,11 @@ server.register({
 
 Creates a new GoodInflux object where:
 
-- `endpoint` - full path to remote server's HTTP API end point to transmit logs (e.g. `http://localhost:8086/write?db=good`)
-- `config` - configuration object
+- `endpoint` - full path to remote server's InfluxDB HTTP API end point to transmit InfluxDB statistics (e.g. `http://localhost:8086/write?db=good`)
+- `config` - configuration object *(Optional)*
 	- `[threshold]` - number of events to hold before transmission. Defaults to `20`. Set to `0` to have every event start transmission instantly. It is strongly suggested to have a set threshold to make data transmission more efficient.
   - `[wreck]` - configuration object to pass into [`wreck`](https://github.com/hapijs/wreck#advanced). Defaults to `{ timeout: 60000, headers: {} }`. `content-type` is always "text/plain".
-
+  - `[metadata]` - arbitrary information you would like to include in your InfluxDB stats.  This helps you query InfluxDB for the statistics you want.
 
 ## Series
 
@@ -77,11 +81,12 @@ time | host | pid | data | tags
 
 ### Ops
 
-time | host | pid | os | proc
------|------|-----|----|-----
+time | host | pid | os | proc | <metadata>
+-----|------|-----|----|------|-----------
 
 - os includes: `cpu1m`, `cpu5m`, `cpu15m`, `freemem`, `totalmem` and `uptime`
 - proc includes: `delay`, `heapTotal`, `heapUsed`, `rss` and `uptime`
+- <metadata> includes any decorators you may have added as part of the `metadata` config option above.
 
 ### Request
 
@@ -95,7 +100,6 @@ time | host | pid | httpVersion | id | instance | labels | method | path | query
 
 referer | remoteAddress | responseTime | statusCode | userAgent
 ---------|---------------|--------------|------------|----------
-
 
 ## License
 

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const Hoek = require('hoek')
+const GoodHttp = require('good-http')
+const Wreck = require('wreck')
+const LineProtocol = require('./line-protocol.js')
+
+const internals = {
+    defaults: {
+        metadata: false
+    }
+}
+
+class GoodInfluxHttp extends GoodHttp {
+    constructor(endpoint, config) {
+        super(endpoint, config)
+        this._settings.schema = 'good-influx'
+        this.config = Hoek.applyToDefaults(internals.defaults, config)
+    }
+    _sendMessages(callback) {
+        const wreckOptions = {
+            payload: this._data
+                .map((event) => LineProtocol.format(event, this.config))
+                .join('\n')
+        }
+
+        Hoek.merge(wreckOptions, this._settings.wreck, false)
+
+        // Prevent this from user tampering
+        wreckOptions.headers['content-type'] = 'text/plain'
+        Wreck.request('post', this._endpoint, wreckOptions, callback)
+    }
+}
+
+module.exports = GoodInfluxHttp

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -1,35 +1,35 @@
-'use strict'
+'use strict';
 
-const Hoek = require('hoek')
-const GoodHttp = require('good-http')
-const Wreck = require('wreck')
-const LineProtocol = require('./line-protocol.js')
+const Hoek = require('hoek');
+const GoodHttp = require('good-http');
+const Wreck = require('wreck');
+const LineProtocol = require('./line-protocol.js');
 
 const internals = {
     defaults: {
         metadata: false
     }
-}
+};
 
 class GoodInfluxHttp extends GoodHttp {
     constructor(endpoint, config) {
-        super(endpoint, config)
-        this._settings.schema = 'good-influx'
-        this.config = Hoek.applyToDefaults(internals.defaults, config)
+        super(endpoint, config);
+        this._settings.schema = 'good-influx';
+        this.config = Hoek.applyToDefaults(internals.defaults, config);
     }
     _sendMessages(callback) {
         const wreckOptions = {
             payload: this._data
                 .map((event) => LineProtocol.format(event, this.config))
                 .join('\n')
-        }
+        };
 
-        Hoek.merge(wreckOptions, this._settings.wreck, false)
+        Hoek.merge(wreckOptions, this._settings.wreck, false);
 
         // Prevent this from user tampering
-        wreckOptions.headers['content-type'] = 'text/plain'
-        Wreck.request('post', this._endpoint, wreckOptions, callback)
+        wreckOptions.headers['content-type'] = 'text/plain';
+        Wreck.request('post', this._endpoint, wreckOptions, callback);
     }
 }
 
-module.exports = GoodInfluxHttp
+module.exports = GoodInfluxHttp;

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -1,26 +1,26 @@
-'use strict'
+'use strict';
 
-const GoodUdp = require('good-udp')
-const Hoek = require('hoek')
-const LineProtocol = require('./line-protocol.js')
+const GoodUdp = require('good-udp');
+const Hoek = require('hoek');
+const LineProtocol = require('./line-protocol.js');
 
 const internals = {
     defaults: {
         metadata: false
     }
-}
+};
 
 class GoodInfluxUdp extends GoodUdp {
     constructor(endpoint, config) {
-        super(endpoint, config)
-        this._settings.schema = 'good-influx'
-        this.config = Hoek.applyToDefaults(internals.defaults, config)
+        super(endpoint, config);
+        this._settings.schema = 'good-influx';
+        this.config = Hoek.applyToDefaults(internals.defaults, config);
     }
 
     _sendMessages(callback) {
         const lineData = this._data
             .map((event) => LineProtocol.format(event, this.config))
-            .join('\n')
+            .join('\n');
 
         const payload = new Buffer(lineData);
 
@@ -29,4 +29,4 @@ class GoodInfluxUdp extends GoodUdp {
     }
 }
 
-module.exports = GoodInfluxUdp
+module.exports = GoodInfluxUdp;

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const GoodUdp = require('good-udp')
+const Hoek = require('hoek')
+const LineProtocol = require('./line-protocol.js')
+
+const internals = {
+    defaults: {
+        metadata: false
+    }
+}
+
+class GoodInfluxUdp extends GoodUdp {
+    constructor(endpoint, config) {
+        super(endpoint, config)
+        this._settings.schema = 'good-influx'
+        this.config = Hoek.applyToDefaults(internals.defaults, config)
+    }
+
+    _sendMessages(callback) {
+        const lineData = this._data
+            .map((event) => LineProtocol.format(event, this.config))
+            .join('\n')
+
+        const payload = new Buffer(lineData);
+
+        // Prevent this from user tampering
+        this._udpClient.send(payload, 0, payload.length, this._endpoint.port, this._endpoint.hostname, callback);
+    }
+}
+
+module.exports = GoodInfluxUdp

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,37 +1,17 @@
 'use strict'
 
-const Hoek = require('hoek');
-const GoodHttp = require('good-http');
-const Wreck = require('wreck');
+const GoodInfluxHttp = require('./good-influx-http')
+const GoodInfluxUdp = require('./good-influx-udp')
+const Url = require('url')
 
-const LineProtocol = require('./line-protocol.js');
-
-const internals = {
-    defaults: {
-        metadata: false
+const GoodInflux = function(endpoint, config) {
+    const endpointUrl = Url.parse(endpoint)
+    if (endpointUrl.protocol === 'udp:') {
+        return new GoodInfluxUdp(endpoint, config)
+    } else if (endpointUrl.protocol === 'http:' || endpointUrl.protocol === 'https:') {
+        return new GoodInfluxHttp(endpoint, config)
     }
+    throw new Error(`Unsupported protocol ${endpointUrl.protocol}. Supported protocols are udp, http or https`)
 }
 
-class GoodInflux extends GoodHttp {
-    constructor(endpoint, config) {
-        super(endpoint, config);
-        this._settings.schema = 'good-influx';
-        this.config = Hoek.applyToDefaults(internals.defaults, config)
-    }
-    _sendMessages(callback) {
-
-        const wreckOptions = {
-            payload: this._data
-                .map((event) => LineProtocol.format(event, this.config))
-                .join('\n')
-        };
-
-        Hoek.merge(wreckOptions, this._settings.wreck, false);
-
-        // Prevent this from user tampering
-        wreckOptions.headers['content-type'] = 'text/plain';
-        Wreck.request('post', this._endpoint, wreckOptions, callback);
-    }
-}
-
-module.exports = GoodInflux;
+module.exports = GoodInflux

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
-'use strict';
-// Load modules
+'use strict'
 
 const Hoek = require('hoek');
 const GoodHttp = require('good-http');
@@ -7,16 +6,23 @@ const Wreck = require('wreck');
 
 const LineProtocol = require('./line-protocol.js');
 
+const internals = {
+    defaults: {
+        metadata: false
+    }
+}
+
 class GoodInflux extends GoodHttp {
     constructor(endpoint, config) {
         super(endpoint, config);
         this._settings.schema = 'good-influx';
+        this.config = Hoek.applyToDefaults(internals.defaults, config)
     }
     _sendMessages(callback) {
 
-        var wreckOptions = {
+        const wreckOptions = {
             payload: this._data
-                .map((event) => LineProtocol.format(event))
+                .map((event) => LineProtocol.format(event, this.config))
                 .join('\n')
         };
 
@@ -27,6 +33,5 @@ class GoodInflux extends GoodHttp {
         Wreck.request('post', this._endpoint, wreckOptions, callback);
     }
 }
-
 
 module.exports = GoodInflux;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,18 @@
-'use strict'
+'use strict';
 
-const GoodInfluxHttp = require('./good-influx-http')
-const GoodInfluxUdp = require('./good-influx-udp')
-const Url = require('url')
+const GoodInfluxHttp = require('./good-influx-http');
+const GoodInfluxUdp = require('./good-influx-udp');
+const Url = require('url');
 
-const GoodInflux = function(endpoint, config) {
-    const endpointUrl = Url.parse(endpoint)
+const GoodInflux = function (endpoint, config) {
+    const endpointUrl = Url.parse(endpoint);
     if (endpointUrl.protocol === 'udp:') {
-        return new GoodInfluxUdp(endpoint, config)
-    } else if (endpointUrl.protocol === 'http:' || endpointUrl.protocol === 'https:') {
-        return new GoodInfluxHttp(endpoint, config)
+        return new GoodInfluxUdp(endpoint, config);
     }
-    throw new Error(`Unsupported protocol ${endpointUrl.protocol}. Supported protocols are udp, http or https`)
-}
+    else if (endpointUrl.protocol === 'http:' || endpointUrl.protocol === 'https:') {
+        return new GoodInfluxHttp(endpoint, config);
+    }
+    throw new Error(`Unsupported protocol ${endpointUrl.protocol}. Supported protocols are udp, http or https`);
+};
 
-module.exports = GoodInflux
+module.exports = GoodInflux;

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -19,7 +19,8 @@ const internals = {
     host: Os.hostname()
 };
 
-internals.Int = (value) => (isNaN(Number(value))) ? value : String(value) + 'i';
+/* eslint-disable no-confusing-arrow */
+internals.Int = (value) => isNaN(Number(value)) ? value : String(value) + 'i';
 
 internals.String = (value) => {
     let str
@@ -48,7 +49,7 @@ internals.formatError = (error) => {
         return internals.String(error);
     }
 
-    let result = {
+    const result = {
         'error.name'    : internals.String(error.name),
         'error.message' : internals.String(error.message),
         'error.stack'   : internals.String(error.stack)
@@ -65,7 +66,6 @@ internals.formatError = (error) => {
 
     return result;
 };
-
 
 internals.values = {
     error: (event) => Object.assign(
@@ -150,7 +150,7 @@ internals.values = {
             remoteAddress : internals.String(Hoek.reach(event, 'source.remoteAddress')),
             responseTime  : internals.Int(event.responseTime),
             statusCode    : internals.Int(event.statusCode),
-            userAgent     : internals.String(Hoek.reach(event, 'source.userAgent')),
+            userAgent     : internals.String(Hoek.reach(event, 'source.userAgent'))
         };
     }
 }
@@ -159,17 +159,22 @@ internals.serialize = (obj) => Object.keys(obj)
     .map((key) => `${key}=${obj[key]}`)
     .join(',');
 
-module.exports.format = (event) => {
-
+module.exports.format = (event, config) => {
     const eventName = event.event;
     const timestamp = event.timestamp;
 
-    let getEventValues = internals.values[eventName];
+    const getEventValues = internals.values[eventName];
     if (!getEventValues) { return; }
 
-    const tags   = internals.serialize(internals.tags(event));
-    const values = internals.serialize(getEventValues(event))
+    const tags = internals.serialize(internals.tags(event));
+    const eventValues = getEventValues(event)
+    if (config.metadata) {
+        Object.keys(config.metadata).forEach( (key) => {
+            eventValues[key] = internals.String(config.metadata[key])
+        })
+    }
+    const values = internals.serialize(eventValues)
 
     // Timestamp in InfluxDB is in nanoseconds
-    return `${eventName},${tags} ${values} ${timestamp}000000`;
+    return `${eventName},${tags} ${values} ${timestamp}000000`
 };

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -22,12 +22,16 @@ const internals = {
 internals.Int = (value) => (isNaN(Number(value))) ? value : String(value) + 'i';
 
 internals.String = (value) => {
+    let str
 
-    const string = (value instanceof Object && !Array.isArray(value)) ?
-        Stringify(value).replace(/"/g, '\\"') :
-        String(value);
+    if (Object.prototype.toString.call(value) === '[object Object]' &&
+        !Array.isArray(value)) {
+        str = Stringify(value).replace(/"/g, '\\"')
+    } else {
+        str = String(value)
+    }
 
-    return `"${string}"`;
+    return `"${str}"`;
 };
 
 internals.tags = (event) => {

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -23,16 +23,17 @@ const internals = {
 internals.Int = (value) => isNaN(Number(value)) ? value : String(value) + 'i';
 
 internals.String = (value) => {
-    let str
+    let string;
 
     if (Object.prototype.toString.call(value) === '[object Object]' &&
         !Array.isArray(value)) {
-        str = Stringify(value).replace(/"/g, '\\"')
-    } else {
-        str = String(value)
+        string = Stringify(value).replace(/"/g, '\\"');
+    }
+    else {
+        string = String(value);
     }
 
-    return `"${str}"`;
+    return `"${string}"`;
 };
 
 internals.tags = (event) => {
@@ -153,7 +154,7 @@ internals.values = {
             userAgent     : internals.String(Hoek.reach(event, 'source.userAgent'))
         };
     }
-}
+};
 
 internals.serialize = (obj) => Object.keys(obj)
     .map((key) => `${key}=${obj[key]}`)
@@ -164,17 +165,19 @@ module.exports.format = (event, config) => {
     const timestamp = event.timestamp;
 
     const getEventValues = internals.values[eventName];
-    if (!getEventValues) { return; }
+    if (!getEventValues) {
+        return;
+    }
 
     const tags = internals.serialize(internals.tags(event));
-    const eventValues = getEventValues(event)
+    const eventValues = getEventValues(event);
     if (config.metadata) {
         Object.keys(config.metadata).forEach( (key) => {
-            eventValues[key] = internals.String(config.metadata[key])
-        })
+            eventValues[key] = internals.String(config.metadata[key]);
+        });
     }
-    const values = internals.serialize(eventValues)
+    const values = internals.serialize(eventValues);
 
     // Timestamp in InfluxDB is in nanoseconds
-    return `${eventName},${tags} ${values} ${timestamp}000000`
+    return `${eventName},${tags} ${values} ${timestamp}000000`;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creditkarma/good-influx",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "repository": "git://github.com/fhemberger/good-influx",
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",
@@ -11,8 +11,9 @@
   "author": "Frederic Hemberger (https://frederic-hemberger.de/)",
   "license": "MIT",
   "dependencies": {
-    "fast-safe-stringify": "1.0.9",
-    "good-http": "6.x.x",
+    "fast-safe-stringify": "^1.0.9",
+    "good-http": "^6.1.2",
+    "good-udp": "^4.0.0",
     "hoek": "4.x.x",
     "wreck": "7.x.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "good-influx",
-  "version": "2.0.0",
+  "name": "@creditkarma/good-influx",
+  "version": "2.0.1",
   "repository": "git://github.com/fhemberger/good-influx",
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",
   "scripts": {
-    "test": "lab -m 5000 -t 100 -v -La code",
+    "test": "lab -m 5000 -t 79 -v -La code",
     "test-cov-html": "lab -m 5000 -r html -o coverage.html -La code"
   },
   "author": "Frederic Hemberger (https://frederic-hemberger.de/)",
@@ -18,10 +18,13 @@
   },
   "devDependencies": {
     "code": "2.x.x",
+    "eslint": "^3.14.0",
+    "eslint-config-hapi": "^10.0.0",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-hapi": "^4.0.0",
+    "eslint-plugin-promise": "^3.4.0",
+    "eslint-plugin-standard": "^2.0.1",
     "lab": "10.x.x"
-  },
-  "peerDependencies": {
-    "good": "7.x.x"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,18 +1,18 @@
-'use strict'
+'use strict';
 
-const GoodInflux = require('../lib/index')
+const GoodInflux = require('../lib/index');
 
-const Stream = require('stream')
-const Http = require('http')
-const Dgram = require('dgram')
+const Stream = require('stream');
+const Http = require('http');
+const Dgram = require('dgram');
 
-const Code = require('code')
-const Lab = require('lab')
-const lab = exports.lab = Lab.script()
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
 
-const describe = lab.describe
-const it = lab.it
-const expect = Code.expect
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
 
 const testEvent = {
     event: 'ops',
@@ -20,7 +20,7 @@ const testEvent = {
     host: 'mytesthost',
     pid: 9876,
     os: {
-        load: [ 1.8408203125, 1.44287109375, 1.15234375 ],
+        load: [1.8408203125, 1.44287109375, 1.15234375],
         mem: {
             total: 6089818112,
             free: 162570240 },
@@ -40,118 +40,118 @@ const testEvent = {
         concurrents: { '8080': 0 },
         responseTimes: {}
     }
-}
+};
 /* eslint max-len: ["error", 440, 4] */
-const expectedMessage = 'ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192,testing="superClutch" 123456789000000'
+const expectedMessage = 'ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192,testing="superClutch" 123456789000000';
 
 const mocks = {
     readStream() {
-        const result = new Stream.Readable({ objectMode: true })
+        const result = new Stream.Readable({ objectMode: true });
         // Need to overwrite this function. For some reason all it does is Error('not implemented')  Very helpful, no?
         /* eslint-disable no-empty-function */
-        result._read = () => {}
-        return result
+        result._read = () => {};
+        return result;
     },
 
     getUri(server, protocol) {
-        const address = server.address()
-        return `${protocol}://${address.address}:${address.port}`
+        const address = server.address();
+        return `${protocol}://${address.address}:${address.port}`;
     },
 
     getHttpServer(done) {
-        let hitCount = 0
+        let hitCount = 0;
         const server = Http.createServer((req, res) => {
-            let data = ''
+            let data = '';
 
             req.on('data', (chunk) => {
-                data += chunk
-            })
+                data += chunk;
+            });
             req.on('end', () => {
-                hitCount += 1
-                const dataRows = data.split('\n')
+                hitCount += 1;
+                const dataRows = data.split('\n');
 
                 // Because threshold is 5, expect 5 events to be sent at a time
-                expect(dataRows.length).to.equal(5)
+                expect(dataRows.length).to.equal(5);
                 dataRows.forEach((datum) => {
-                    expect(datum).to.equal(expectedMessage)
-                })
+                    expect(datum).to.equal(expectedMessage);
+                });
 
-                res.end()
+                res.end();
                 if (hitCount >= 2) {
-                    server.close(done)
+                    server.close(done);
                 }
-            })
-        })
+            });
+        });
 
-        return server
+        return server;
     },
 
     getUdpServer(done) {
-        let hitCount = 0
-        const server = Dgram.createSocket('udp4')
+        let hitCount = 0;
+        const server = Dgram.createSocket('udp4');
         server.on('message', (msg) => {
-            hitCount += 1
-            const splitMessage = msg.toString().split('\n')
+            hitCount += 1;
+            const splitMessage = msg.toString().split('\n');
 
             // Because threshold is 5, expect 5 events to be sent at a time
-            expect(splitMessage.length).to.equal(5)
+            expect(splitMessage.length).to.equal(5);
             splitMessage.forEach((msgRow) => {
-                expect(msgRow).to.equal(expectedMessage)
-            })
+                expect(msgRow).to.equal(expectedMessage);
+            });
             if (hitCount >= 2) {
-                server.close(done)
+                server.close(done);
             }
-        })
-        server.bind(9876, '127.0.0.1')
-        return server
+        });
+        server.bind(9876, '127.0.0.1');
+        return server;
     }
-}
+};
 
 describe('GoodInflux', () => {
     it('Http URL => Sends events in a stream to HTTP server', (done) => {
-        const server = mocks.getHttpServer(done)
-        const stream = mocks.readStream()
+        const server = mocks.getHttpServer(done);
+        const stream = mocks.readStream();
 
         server.listen(0, '127.0.0.1', () => {
             const reporter = new GoodInflux(mocks.getUri(server, 'http'), {
                 threshold: 5,
                 metadata: { testing: 'superClutch' }
-            })
+            });
 
-            stream.pipe(reporter)
+            stream.pipe(reporter);
 
             // Important to send 10 events. Threshold is 5, so two batches of events are sent.
             // Sending two batches proves that the callback is being passed properly to Wreck.request.
             for (let i = 0; i < 10; i += 1) {
-                stream.push(testEvent)
+                stream.push(testEvent);
             }
-        })
-    })
+        });
+    });
 
     it('Udp URL => Sends events in a stream to UDP server', (done) => {
-        const server = mocks.getUdpServer(done)
-        const stream = mocks.readStream()
+        const server = mocks.getUdpServer(done);
+        const stream = mocks.readStream();
 
         server.on('listening', () => {
             const reporter = new GoodInflux(mocks.getUri(server, 'udp'), {
                 threshold: 5,
                 metadata: { testing: 'superClutch' }
-            })
+            });
 
-            stream.pipe(reporter)
+            stream.pipe(reporter);
 
             // Important to send 10 events. Threshold is 5, so two batches of events are sent.
             // Sending two batches proves that the callback is being passed properly to this._udpClient.send.
             for (let i = 0; i < 10; i += 1) {
-                stream.push(testEvent)
+                stream.push(testEvent);
             }
-        })
-    })
+        });
+    });
 
     it('Unsupported protocol => throw error', (done) => {
         expect(() => {
-            return new GoodInflux('ftp://abcd:1234', {})
-        }).to.throw(Error, 'Unsupported protocol ftp:. Supported protocols are udp, http or https')
-        done()
-    })
-})
+            return new GoodInflux('ftp://abcd:1234', {});
+        }).to.throw(Error, 'Unsupported protocol ftp:. Supported protocols are udp, http or https');
+        done();
+    });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ const GoodInflux = require('../lib/index')
 
 const Stream = require('stream')
 const Http = require('http')
+const Dgram = require('dgram')
 
 const Code = require('code')
 const Lab = require('lab')
@@ -40,6 +41,8 @@ const testEvent = {
         responseTimes: {}
     }
 }
+/* eslint max-len: ["error", 440, 4] */
+const expectedMessage = 'ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192,testing="superClutch" 123456789000000'
 
 const mocks = {
     readStream() {
@@ -50,12 +53,13 @@ const mocks = {
         return result
     },
 
-    getUri(server) {
+    getUri(server, protocol) {
         const address = server.address()
-        return `http://${address.address}:${address.port}`
+        return `${protocol}://${address.address}:${address.port}`
     },
 
-    getServer(done) {
+    getHttpServer(done) {
+        let hitCount = 0
         const server = Http.createServer((req, res) => {
             let data = ''
 
@@ -63,40 +67,91 @@ const mocks = {
                 data += chunk
             })
             req.on('end', () => {
+                hitCount += 1
                 const dataRows = data.split('\n')
-                expect(dataRows.length).to.be.greaterThan(1)
 
+                // Because threshold is 5, expect 5 events to be sent at a time
+                expect(dataRows.length).to.equal(5)
                 dataRows.forEach((datum) => {
-                    /* eslint max-len: ["error", 880, 4] */
-                    expect(datum).to.equal('ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192,testing="superClutch" 123456789000000')
+                    expect(datum).to.equal(expectedMessage)
                 })
 
                 res.end()
-                server.close(done)
+                if (hitCount >= 2) {
+                    server.close(done)
+                }
             })
         })
 
+        return server
+    },
+
+    getUdpServer(done) {
+        let hitCount = 0
+        const server = Dgram.createSocket('udp4')
+        server.on('message', (msg) => {
+            hitCount += 1
+            const splitMessage = msg.toString().split('\n')
+
+            // Because threshold is 5, expect 5 events to be sent at a time
+            expect(splitMessage.length).to.equal(5)
+            splitMessage.forEach((msgRow) => {
+                expect(msgRow).to.equal(expectedMessage)
+            })
+            if (hitCount >= 2) {
+                server.close(done)
+            }
+        })
+        server.bind(9876, '127.0.0.1')
         return server
     }
 }
 
 describe('GoodInflux', () => {
-    it('Sends events in a stream', (done) => {
-        const server = mocks.getServer(done)
-
+    it('Http URL => Sends events in a stream to HTTP server', (done) => {
+        const server = mocks.getHttpServer(done)
         const stream = mocks.readStream()
 
         server.listen(0, '127.0.0.1', () => {
-            const reporter = new GoodInflux(mocks.getUri(server), {
+            const reporter = new GoodInflux(mocks.getUri(server, 'http'), {
                 threshold: 5,
                 metadata: { testing: 'superClutch' }
             })
 
             stream.pipe(reporter)
 
-            for (let i = 0; i < 5; i += 1) {
+            // Important to send 10 events. Threshold is 5, so two batches of events are sent.
+            // Sending two batches proves that the callback is being passed properly to Wreck.request.
+            for (let i = 0; i < 10; i += 1) {
                 stream.push(testEvent)
             }
         })
+    })
+
+    it('Udp URL => Sends events in a stream to UDP server', (done) => {
+        const server = mocks.getUdpServer(done)
+        const stream = mocks.readStream()
+
+        server.on('listening', () => {
+            const reporter = new GoodInflux(mocks.getUri(server, 'udp'), {
+                threshold: 5,
+                metadata: { testing: 'superClutch' }
+            })
+
+            stream.pipe(reporter)
+
+            // Important to send 10 events. Threshold is 5, so two batches of events are sent.
+            // Sending two batches proves that the callback is being passed properly to this._udpClient.send.
+            for (let i = 0; i < 10; i += 1) {
+                stream.push(testEvent)
+            }
+        })
+    })
+
+    it('Unsupported protocol => throw error', (done) => {
+        expect(() => {
+            return new GoodInflux('ftp://abcd:1234', {})
+        }).to.throw(Error, 'Unsupported protocol ftp:. Supported protocols are udp, http or https')
+        done()
     })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const GoodInflux = require('../lib/index')
+
+const Stream = require('stream')
+const Http = require('http')
+
+const Code = require('code')
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+
+const describe = lab.describe
+const it = lab.it
+const expect = Code.expect
+
+const testEvent = {
+    event: 'ops',
+    timestamp: 123456789,
+    host: 'mytesthost',
+    pid: 9876,
+    os: {
+        load: [ 1.8408203125, 1.44287109375, 1.15234375 ],
+        mem: {
+            total: 6089818112,
+            free: 162570240 },
+        uptime: 11546
+    },
+    proc: {
+        uptime: 18.192,
+        mem: {
+            rss: 55812096,
+            heapTotal: 41546080,
+            heapUsed: 27708712
+        },
+        delay: 0.07090700045228004
+    },
+    load: {
+        requests: {},
+        concurrents: { '8080': 0 },
+        responseTimes: {}
+    }
+}
+
+const mocks = {
+    readStream() {
+        const result = new Stream.Readable({ objectMode: true })
+        // Need to overwrite this function. For some reason all it does is Error('not implemented')  Very helpful, no?
+        /* eslint-disable no-empty-function */
+        result._read = () => {}
+        return result
+    },
+
+    getUri(server) {
+        const address = server.address()
+        return `http://${address.address}:${address.port}`
+    },
+
+    getServer(done) {
+        const server = Http.createServer((req, res) => {
+            let data = ''
+
+            req.on('data', (chunk) => {
+                data += chunk
+            })
+            req.on('end', () => {
+                const dataRows = data.split('\n')
+                expect(dataRows.length).to.be.greaterThan(1)
+
+                dataRows.forEach((datum) => {
+                    /* eslint max-len: ["error", 880, 4] */
+                    expect(datum).to.equal('ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192,testing="superClutch" 123456789000000')
+                })
+
+                res.end()
+                server.close(done)
+            })
+        })
+
+        return server
+    }
+}
+
+describe('GoodInflux', () => {
+    it('Sends events in a stream', (done) => {
+        const server = mocks.getServer(done)
+
+        const stream = mocks.readStream()
+
+        server.listen(0, '127.0.0.1', () => {
+            const reporter = new GoodInflux(mocks.getUri(server), {
+                threshold: 5,
+                metadata: { testing: 'superClutch' }
+            })
+
+            stream.pipe(reporter)
+
+            for (let i = 0; i < 5; i += 1) {
+                stream.push(testEvent)
+            }
+        })
+    })
+})


### PR DESCRIPTION
After using this excellent module for Influx logging in a couple of our Hapi services, we came up with some additional features to add.  We hope the community finds them helpful.

* Adds UDP support.  The module will now auto-detect `http(s)` or `udp` from the URL and use the appropriate client.
* Adds the ability to decorate events with custom metadata.
  * We wanted a way to separate ops events from several different services.  Host would work in many cases, but since we run in Docker containers the host is a hash that is meaningless.  We added the ability to decorate events with arbitrary metadata.
* Fixes issue with response event serialization silently failing.
* Adds some unit tests for the HTTP and UDP versions.  Coverage is now at 84%.
* Added linting rules from the Hapi style guide.  Fixed all linting issues.