### PR TITLE
Add load data events

### DIFF
--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -12,6 +12,13 @@ const internals = {
 
 class GoodInfluxUdp extends GoodUdp {
     constructor(endpoint, config) {
+        if (config.threshold) {
+            if (config.threshold > 5) {
+                config.threshold = 5;
+            }
+        } else {
+            config.threshold = 5;
+        }
         super(endpoint, config);
         this._settings.schema = 'good-influx';
         this.config = Hoek.applyToDefaults(internals.defaults, config);

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -12,10 +12,8 @@ const internals = {
 
 class GoodInfluxUdp extends GoodUdp {
     constructor(endpoint, config) {
-        if (config.threshold) {
-            if (config.threshold > 5) {
-                config.threshold = 5;
-            }
+        if (config.threshold && config.threshold > 5) {
+            config.threshold = 5;
         } else {
             config.threshold = 5;
         }

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -146,7 +146,7 @@ internals.values = {
             labels        : internals.String(event.labels),
             method        : internals.String(event.method && event.method.toUpperCase()),
             path          : internals.String(event.path),
-            query         : Qs.stringify(internals.String(event.query)),
+            query         : internals.String(Qs.stringify(event.query)),
             referer       : internals.String(Hoek.reach(event, 'source.referer')),
             remoteAddress : internals.String(Hoek.reach(event, 'source.remoteAddress')),
             responseTime  : internals.Int(event.responseTime),

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -164,7 +164,7 @@ internals.values = {
         return Object.keys(responseTimes).map((port) => {
             const stats = {};
             Object.keys(responseTimes[port]).map((aggregator) => {
-                stats[aggregator] = responseTimes[port][aggregator] === null ? 0 : responseTimes[port][aggregator];
+                stats[aggregator] = isNaN(responseTimes[port][aggregator] ? 0 : responseTimes[port][aggregator];
                 return null;
             });
             const tags = {

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -113,6 +113,68 @@ internals.values = {
             'proc.uptime'    : Hoek.reach(event, 'proc.uptime')
         };
     },
+    ops_requests: (event) => {
+        const requests = Hoek.reach(event, 'load.requests');
+        if (Object.keys(requests).length === 0) {
+            return null;
+        }
+        return Object.keys(requests).map((port) => {
+            const statusCodesValues = {};
+            Object.keys(requests[port].statusCodes).map((code) => {
+                const key = 'requests' + code;
+                statusCodesValues[key] = requests[port].statusCodes[code];
+                return null;
+            });
+
+            return Object.assign({
+                'port': port,
+                'requestsTotal': requests[port].total,
+                'requestsDisconnects': requests[port].disconnects
+            }, statusCodesValues);
+        });
+    },
+    ops_concurrents: (event) => {
+        const concurrents = Hoek.reach(event, 'load.concurrents');
+        if (Object.keys(concurrents).length === 0) {
+            return null;
+        }
+
+        return Object.keys(concurrents).map((port) => {
+            return {
+                'port': port,
+                'concurrents': concurrents[port]
+            };
+        });
+    },
+    ops_responseTimes: (event) => {
+        const responseTimes = Hoek.reach(event, 'load.responseTimes');
+        if (Object.keys(responseTimes).length === 0) {
+            return null;
+        }
+        return Object.keys(responseTimes).map((port) => {
+            const stats = {};
+            Object.keys(responseTimes[port]).map((aggregator) => {
+                stats[aggregator] = responseTimes[port][aggregator];
+                return null;
+            });
+            return Object.assign({
+                'port': port
+            }, stats);
+        });
+    },
+    ops_sockets: (event) => {
+        const sockets = Hoek.reach(event, 'load.sockets');
+        if (Object.keys(sockets).length === 0) {
+            return null;
+        }
+        const socketsValues = {};
+        Object.keys(sockets).map((protocol) => {
+            const key = protocol + 'Total';
+            socketsValues[key] = sockets[protocol].total;
+            return null;
+        });
+        return [socketsValues];
+    },
     request: (event) => {
 
         if (event.data instanceof Error) {
@@ -160,6 +222,23 @@ internals.serialize = (obj) => Object.keys(obj)
     .map((key) => `${key}=${obj[key]}`)
     .join(',');
 
+const formatHelper = function (eventName, timestamp, tags, eventValues, config) {
+    if (eventValues !== null) {
+        const finalEventValues = eventValues.map((value) => {
+            if (config.metadata) {
+                Object.keys(config.metadata).forEach( (key) => {
+                    value[key] = internals.String(config.metadata[key]);
+                });
+            }
+            const fields = internals.serialize(value);
+            // Timestamp in InfluxDB is in nanoseconds
+            return `${eventName},${tags} ${fields} ${timestamp}000000`;
+        });
+        return finalEventValues;
+    }
+    return null;
+};
+
 module.exports.format = (event, config) => {
     const eventName = event.event;
     const timestamp = event.timestamp;
@@ -176,8 +255,26 @@ module.exports.format = (event, config) => {
             eventValues[key] = internals.String(config.metadata[key]);
         });
     }
+
     const values = internals.serialize(eventValues);
 
+    let loadValues = [];
+    if (eventName === 'ops') {
+        const requests = internals.values.ops_requests(event);
+        loadValues = loadValues.concat(formatHelper('ops_requests',timestamp,tags,requests,config));
+
+        const concurrents = internals.values.ops_concurrents(event);
+        loadValues = loadValues.concat(formatHelper('ops_concurrents',timestamp,tags,concurrents,config));
+
+        const responseTimes = internals.values.ops_responseTimes(event);
+        loadValues = loadValues.concat(formatHelper('ops_responseTimes',timestamp,tags,responseTimes,config));
+
+        const sockets = internals.values.ops_sockets(event);
+        loadValues = loadValues.concat(formatHelper('ops_sockets',timestamp,tags,sockets,config));
+    }
     // Timestamp in InfluxDB is in nanoseconds
-    return `${eventName},${tags} ${values} ${timestamp}000000`;
+    if (loadValues.length === 0) {
+        return `${eventName},${tags} ${values} ${timestamp}000000`;
+    }
+    return [`${eventName},${tags} ${values} ${timestamp}000000`].concat(loadValues).join('\n');
 };

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -125,12 +125,18 @@ internals.values = {
                 statusCodesValues[key] = requests[port].statusCodes[code];
                 return null;
             });
-
-            return Object.assign({
-                'port': port,
+            const tags = {
+                'port': port
+            };
+            const fields = Object.assign({
                 'requestsTotal': requests[port].total,
                 'requestsDisconnects': requests[port].disconnects
-            }, statusCodesValues);
+            },statusCodesValues);
+
+            return {
+                'tags': tags,
+                'fields': fields
+            };
         });
     },
     ops_concurrents: (event) => {
@@ -141,8 +147,12 @@ internals.values = {
 
         return Object.keys(concurrents).map((port) => {
             return {
-                'port': port,
-                'concurrents': concurrents[port]
+                'tags' : {
+                    'port': port
+                },
+                'fields' : {
+                    'concurrents': concurrents[port]
+                }
             };
         });
     },
@@ -157,9 +167,13 @@ internals.values = {
                 stats[aggregator] = responseTimes[port][aggregator];
                 return null;
             });
-            return Object.assign({
+            const tags = {
                 'port': port
-            }, stats);
+            };
+            return {
+                'tags': tags,
+                'fields': stats
+            };
         });
     },
     ops_sockets: (event) => {
@@ -167,10 +181,13 @@ internals.values = {
         if (Object.keys(sockets).length === 0) {
             return null;
         }
-        const socketsValues = {};
+        let socketsValues = {
+            'tags': {},
+            'fields': {}
+        };
         Object.keys(sockets).map((protocol) => {
             const key = protocol + 'Total';
-            socketsValues[key] = sockets[protocol].total;
+            socketsValues.fields[key] = sockets[protocol].total;
             return null;
         });
         return [socketsValues];
@@ -222,17 +239,45 @@ internals.serialize = (obj) => Object.keys(obj)
     .map((key) => `${key}=${obj[key]}`)
     .join(',');
 
-const formatHelper = function (eventName, timestamp, tags, eventValues, config) {
+
+const opsFormat = function (event, config) {
+    const timestamp = event.timestamp;
+    const tags = internals.serialize(internals.tags(event));
+
+    let loadValues = [];
+    const requests = internals.values.ops_requests(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_requests',timestamp,tags,requests,config));
+
+    const concurrents = internals.values.ops_concurrents(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_concurrents',timestamp,tags,concurrents,config));
+
+    const responseTimes = internals.values.ops_responseTimes(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_responseTimes',timestamp,tags,responseTimes,config));
+
+    const sockets = internals.values.ops_sockets(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_sockets',timestamp,tags,sockets,config));
+    return loadValues;
+}
+
+const opsFormatHelper = function (eventName, timestamp, tags, eventValues, config) {
     if (eventValues !== null) {
         const finalEventValues = eventValues.map((value) => {
             if (config.metadata) {
                 Object.keys(config.metadata).forEach( (key) => {
-                    value[key] = internals.String(config.metadata[key]);
+                    value.fields[key] = internals.String(config.metadata[key]);
                 });
             }
-            const fields = internals.serialize(value);
+
+            let finalTags = '';
+            const fields = internals.serialize(value.fields);
+            if (value.tags && Object.keys(value.tags).length > 0) {
+                const eventTags = internals.serialize(value.tags);
+                finalTags = [tags,eventTags].join(',');
+            } else {
+                finalTags = tags;
+            }
             // Timestamp in InfluxDB is in nanoseconds
-            return `${eventName},${tags} ${fields} ${timestamp}000000`;
+            return `${eventName},${finalTags} ${fields} ${timestamp}000000`;
         });
         return finalEventValues;
     }
@@ -260,17 +305,7 @@ module.exports.format = (event, config) => {
 
     let loadValues = [];
     if (eventName === 'ops') {
-        const requests = internals.values.ops_requests(event);
-        loadValues = loadValues.concat(formatHelper('ops_requests',timestamp,tags,requests,config));
-
-        const concurrents = internals.values.ops_concurrents(event);
-        loadValues = loadValues.concat(formatHelper('ops_concurrents',timestamp,tags,concurrents,config));
-
-        const responseTimes = internals.values.ops_responseTimes(event);
-        loadValues = loadValues.concat(formatHelper('ops_responseTimes',timestamp,tags,responseTimes,config));
-
-        const sockets = internals.values.ops_sockets(event);
-        loadValues = loadValues.concat(formatHelper('ops_sockets',timestamp,tags,sockets,config));
+        loadValues = opsFormat(event,config);
     }
     // Timestamp in InfluxDB is in nanoseconds
     if (loadValues.length === 0) {

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -236,7 +236,7 @@ const formatHelper = function (eventName, timestamp, tags, eventValues, config) 
         });
         return finalEventValues;
     }
-    return null;
+    return [];
 };
 
 module.exports.format = (event, config) => {

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -12,6 +12,7 @@ const Qs = require('querystring');
 const Url = require('url');
 const Hoek = require('hoek');
 const Stringify = require('fast-safe-stringify');
+const opsFormatter = require('./ops-format');
 
 // Declare internals
 
@@ -113,85 +114,6 @@ internals.values = {
             'proc.uptime'    : Hoek.reach(event, 'proc.uptime')
         };
     },
-    ops_requests: (event) => {
-        const requests = Hoek.reach(event, 'load.requests');
-        if (Object.keys(requests).length === 0) {
-            return null;
-        }
-        return Object.keys(requests).map((port) => {
-            const statusCodesValues = {};
-            Object.keys(requests[port].statusCodes).map((code) => {
-                const key = 'requests' + code;
-                statusCodesValues[key] = requests[port].statusCodes[code];
-                return null;
-            });
-            const tags = {
-                'port': port
-            };
-            const fields = Object.assign({
-                'requestsTotal': requests[port].total,
-                'requestsDisconnects': requests[port].disconnects
-            },statusCodesValues);
-
-            return {
-                'tags': tags,
-                'fields': fields
-            };
-        });
-    },
-    ops_concurrents: (event) => {
-        const concurrents = Hoek.reach(event, 'load.concurrents');
-        if (Object.keys(concurrents).length === 0) {
-            return null;
-        }
-
-        return Object.keys(concurrents).map((port) => {
-            return {
-                'tags' : {
-                    'port': port
-                },
-                'fields' : {
-                    'concurrents': concurrents[port]
-                }
-            };
-        });
-    },
-    ops_responseTimes: (event) => {
-        const responseTimes = Hoek.reach(event, 'load.responseTimes');
-        if (Object.keys(responseTimes).length === 0) {
-            return null;
-        }
-        return Object.keys(responseTimes).map((port) => {
-            const stats = {};
-            Object.keys(responseTimes[port]).map((aggregator) => {
-                stats[aggregator] = isNaN(responseTimes[port][aggregator]) ? 0 : responseTimes[port][aggregator];
-                return null;
-            });
-            const tags = {
-                'port': port
-            };
-            return {
-                'tags': tags,
-                'fields': stats
-            };
-        });
-    },
-    ops_sockets: (event) => {
-        const sockets = Hoek.reach(event, 'load.sockets');
-        if (Object.keys(sockets).length === 0) {
-            return null;
-        }
-        let socketsValues = {
-            'tags': {},
-            'fields': {}
-        };
-        Object.keys(sockets).map((protocol) => {
-            const key = protocol + 'Total';
-            socketsValues.fields[key] = sockets[protocol].total;
-            return null;
-        });
-        return [socketsValues];
-    },
     request: (event) => {
 
         if (event.data instanceof Error) {
@@ -239,51 +161,6 @@ internals.serialize = (obj) => Object.keys(obj)
     .map((key) => `${key}=${obj[key]}`)
     .join(',');
 
-
-const opsFormat = function (event, config) {
-    const timestamp = event.timestamp;
-    const tags = internals.serialize(internals.tags(event));
-
-    let loadValues = [];
-    const requests = internals.values.ops_requests(event);
-    loadValues = loadValues.concat(opsFormatHelper('ops_requests',timestamp,tags,requests,config));
-
-    const concurrents = internals.values.ops_concurrents(event);
-    loadValues = loadValues.concat(opsFormatHelper('ops_concurrents',timestamp,tags,concurrents,config));
-
-    const responseTimes = internals.values.ops_responseTimes(event);
-    loadValues = loadValues.concat(opsFormatHelper('ops_responseTimes',timestamp,tags,responseTimes,config));
-
-    const sockets = internals.values.ops_sockets(event);
-    loadValues = loadValues.concat(opsFormatHelper('ops_sockets',timestamp,tags,sockets,config));
-    return loadValues;
-}
-
-const opsFormatHelper = function (eventName, timestamp, tags, eventValues, config) {
-    if (eventValues !== null) {
-        const finalEventValues = eventValues.map((value) => {
-            if (config.metadata) {
-                Object.keys(config.metadata).forEach( (key) => {
-                    value.fields[key] = internals.String(config.metadata[key]);
-                });
-            }
-
-            let finalTags = '';
-            const fields = internals.serialize(value.fields);
-            if (value.tags && Object.keys(value.tags).length > 0) {
-                const eventTags = internals.serialize(value.tags);
-                finalTags = [tags,eventTags].join(',');
-            } else {
-                finalTags = tags;
-            }
-            // Timestamp in InfluxDB is in nanoseconds
-            return `${eventName},${finalTags} ${fields} ${timestamp}000000`;
-        });
-        return finalEventValues;
-    }
-    return [];
-};
-
 module.exports.format = (event, config) => {
     const eventName = event.event;
     const timestamp = event.timestamp;
@@ -305,7 +182,7 @@ module.exports.format = (event, config) => {
 
     let loadValues = [];
     if (eventName === 'ops') {
-        loadValues = opsFormat(event,config);
+        loadValues = opsFormatter.format(event,config);
     }
     // Timestamp in InfluxDB is in nanoseconds
     if (loadValues.length === 0) {

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -164,7 +164,7 @@ internals.values = {
         return Object.keys(responseTimes).map((port) => {
             const stats = {};
             Object.keys(responseTimes[port]).map((aggregator) => {
-                stats[aggregator] = responseTimes[port][aggregator];
+                stats[aggregator] = responseTimes[port][aggregator] === null ? 0 : responseTimes[port][aggregator];
                 return null;
             });
             const tags = {

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -164,7 +164,7 @@ internals.values = {
         return Object.keys(responseTimes).map((port) => {
             const stats = {};
             Object.keys(responseTimes[port]).map((aggregator) => {
-                stats[aggregator] = isNaN(responseTimes[port][aggregator] ? 0 : responseTimes[port][aggregator];
+                stats[aggregator] = isNaN(responseTimes[port][aggregator]) ? 0 : responseTimes[port][aggregator];
                 return null;
             });
             const tags = {

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -8,7 +8,7 @@
 // Load modules
 
 const Os = require('os');
-const Qs = require('querystring');
+const Querystring = require('querystring');
 const Url = require('url');
 const Hoek = require('hoek');
 const Stringify = require('fast-safe-stringify');
@@ -21,7 +21,14 @@ const internals = {
 };
 
 /* eslint-disable no-confusing-arrow */
-internals.Int = (value) => isNaN(Number(value)) ? value : String(value) + 'i';
+//internals.Int = (value) => isNaN(Number(value)) ? value : String(value) + 'i';
+internals.Int = function(value) {
+  if (isNaN(Number(value))) {
+        return value;
+    } else {
+        return `${String(value)}i`;
+    }
+};
 
 internals.String = (value) => {
     let string;
@@ -38,7 +45,6 @@ internals.String = (value) => {
 };
 
 internals.tags = (event) => {
-
     return {
         host : event.host || internals.host,
         pid  : event.pid
@@ -147,7 +153,7 @@ internals.values = {
             labels        : internals.String(event.labels),
             method        : internals.String(event.method && event.method.toUpperCase()),
             path          : internals.String(event.path),
-            query         : internals.String(Qs.stringify(event.query)),
+            query         : internals.String(Querystring.stringify(event.query)),
             referer       : internals.String(Hoek.reach(event, 'source.referer')),
             remoteAddress : internals.String(Hoek.reach(event, 'source.remoteAddress')),
             responseTime  : internals.Int(event.responseTime),
@@ -157,9 +163,15 @@ internals.values = {
     }
 };
 
-internals.serialize = (obj) => Object.keys(obj)
+//internals.serialize = (obj) => Object.keys(obj)
+//    .map((key) => `${key}=${obj[key]}`)
+//    .join(',');
+
+internals.serialize = function(obj) {
+  return Object.keys(obj)
     .map((key) => `${key}=${obj[key]}`)
-    .join(',');
+    .join(',')
+};
 
 module.exports.format = (event, config) => {
     const eventName = event.event;
@@ -184,9 +196,10 @@ module.exports.format = (event, config) => {
     if (eventName === 'ops') {
         loadValues = opsFormatter.format(event,config);
     }
+    const eventValue = `${eventName},${tags} ${values} ${timestamp}000000`;
     // Timestamp in InfluxDB is in nanoseconds
     if (loadValues.length === 0) {
-        return `${eventName},${tags} ${values} ${timestamp}000000`;
+        return eventValue;
     }
-    return [`${eventName},${tags} ${values} ${timestamp}000000`].concat(loadValues).join('\n');
+    return [eventValue].concat(loadValues).join('\n');
 };

--- a/lib/ops-format.js
+++ b/lib/ops-format.js
@@ -42,102 +42,102 @@ internals.serialize = (obj) => Object.keys(obj)
     .map((key) => `${key}=${obj[key]}`)
     .join(',');
 
-
-internals.values = {
-    ops_requests: (event) => {
-        const requests = Hoek.reach(event, 'load.requests');
-        if (Object.keys(requests).length === 0) {
-            return null;
-        }
-        return Object.keys(requests).map((port) => {
-            const statusCodesValues = {};
-            Object.keys(requests[port].statusCodes).map((code) => {
-                const key = 'requests' + code;
-                statusCodesValues[key] = requests[port].statusCodes[code];
-                return null;
-            });
-            const tags = {
-                'port': port
-            };
-            const fields = Object.assign({
-                'requestsTotal': requests[port].total,
-                'requestsDisconnects': requests[port].disconnects
-            },statusCodesValues);
-
-            return {
-                'tags': tags,
-                'fields': fields
-            };
-        });
-    },
-    ops_concurrents: (event) => {
-        const concurrents = Hoek.reach(event, 'load.concurrents');
-        if (Object.keys(concurrents).length === 0) {
-            return null;
-        }
-
-        return Object.keys(concurrents).map((port) => {
-            return {
-                'tags' : {
-                    'port': port
-                },
-                'fields' : {
-                    'concurrents': concurrents[port]
-                }
-            };
-        });
-    },
-    ops_responseTimes: (event) => {
-        const responseTimes = Hoek.reach(event, 'load.responseTimes');
-        if (Object.keys(responseTimes).length === 0) {
-            return null;
-        }
-        return Object.keys(responseTimes).map((port) => {
-            const stats = {};
-            Object.keys(responseTimes[port]).forEach((aggregator) => {
-                stats[aggregator] = isNaN(responseTimes[port][aggregator]) || (responseTimes[port][aggregator] === null) ? 0 : responseTimes[port][aggregator];
-            });
-            const tags = {
-                'port': port
-            };
-            return {
-                'tags': tags,
-                'fields': stats
-            };
-        });
-    },
-    ops_sockets: (event) => {
-        const sockets = Hoek.reach(event, 'load.sockets');
-        if (Object.keys(sockets).length === 0) {
-            return null;
-        }
-        let socketsValues = {
-            'tags': {},
-            'fields': {}
-        };
-        Object.keys(sockets).forEach((protocol) => {
-            const key = protocol + 'Total';
-            socketsValues.fields[key] = sockets[protocol].total;
-        });
-        return [socketsValues];
+const opsRequests = (event) => {
+    const requests = Hoek.reach(event, 'load.requests');
+    if (Object.keys(requests).length === 0) {
+        return null;
     }
+    return Object.keys(requests).map((port) => {
+        const statusCodesValues = {};
+        Object.keys(requests[port].statusCodes).map((code) => {
+            const key = 'requests' + code;
+            statusCodesValues[key] = requests[port].statusCodes[code];
+            return null;
+        });
+        const tags = {
+            'port': port
+        };
+        const fields = Object.assign({
+            'requestsTotal': requests[port].total,
+            'requestsDisconnects': requests[port].disconnects
+        },statusCodesValues);
+
+        return {
+            'tags': tags,
+            'fields': fields
+        };
+    });
 };
+
+const opsConcurrents = (event) => {
+    const concurrents = Hoek.reach(event, 'load.concurrents');
+    if (Object.keys(concurrents).length === 0) {
+        return null;
+    }
+
+    return Object.keys(concurrents).map((port) => {
+        return {
+            'tags' : {
+                'port': port
+            },
+            'fields' : {
+                'concurrents': concurrents[port]
+            }
+        };
+    });
+};
+
+const opsResponseTimes = (event) => {
+    const responseTimes = Hoek.reach(event, 'load.responseTimes');
+    if (Object.keys(responseTimes).length === 0) {
+        return null;
+    }
+    return Object.keys(responseTimes).map((port) => {
+        const stats = {};
+        Object.keys(responseTimes[port]).forEach((aggregator) => {
+            stats[aggregator] = isNaN(responseTimes[port][aggregator]) || (responseTimes[port][aggregator] === null) ? 0 : responseTimes[port][aggregator];
+        });
+        const tags = {
+            'port': port
+        };
+        return {
+            'tags': tags,
+            'fields': stats
+        };
+    });
+};
+
+const opsSockets = (event) => {
+    const sockets = Hoek.reach(event, 'load.sockets');
+    if (Object.keys(sockets).length === 0) {
+        return null;
+    }
+    let socketsValues = {
+        'tags': {},
+        'fields': {}
+    };
+    Object.keys(sockets).forEach((protocol) => {
+        const key = protocol + 'Total';
+        socketsValues.fields[key] = sockets[protocol].total;
+    });
+    return [socketsValues];
+}
 
 const opsFormat = function (event, config) {
     const timestamp = event.timestamp;
     const tags = internals.serialize(internals.tags(event));
 
     let loadValues = [];
-    const requests = internals.values.ops_requests(event);
+    const requests = opsRequests(event);
     loadValues = loadValues.concat(opsFormatHelper('ops_requests',timestamp,tags,requests,config));
 
-    const concurrents = internals.values.ops_concurrents(event);
+    const concurrents = opsConcurrents(event);
     loadValues = loadValues.concat(opsFormatHelper('ops_concurrents',timestamp,tags,concurrents,config));
 
-    const responseTimes = internals.values.ops_responseTimes(event);
+    const responseTimes = opsResponseTimes(event);
     loadValues = loadValues.concat(opsFormatHelper('ops_responseTimes',timestamp,tags,responseTimes,config));
 
-    const sockets = internals.values.ops_sockets(event);
+    const sockets = opsSockets(event);
     loadValues = loadValues.concat(opsFormatHelper('ops_sockets',timestamp,tags,sockets,config));
     return loadValues;
 }

--- a/lib/ops-format.js
+++ b/lib/ops-format.js
@@ -1,0 +1,172 @@
+'use strict';
+// Load modules
+
+const Os = require('os');
+const Qs = require('querystring');
+const Url = require('url');
+const Hoek = require('hoek');
+const Stringify = require('fast-safe-stringify');
+
+// Declare internals
+
+const internals = {
+    host: Os.hostname()
+};
+
+/* eslint-disable no-confusing-arrow */
+internals.Int = (value) => isNaN(Number(value)) ? value : String(value) + 'i';
+
+internals.String = (value) => {
+    let string;
+
+    if (Object.prototype.toString.call(value) === '[object Object]' &&
+        !Array.isArray(value)) {
+        string = Stringify(value).replace(/"/g, '\\"');
+    }
+    else {
+        string = String(value);
+    }
+
+    return `"${string}"`;
+};
+
+internals.tags = (event) => {
+
+    return {
+        host : event.host || internals.host,
+        pid  : event.pid
+    };
+};
+
+internals.serialize = (obj) => Object.keys(obj)
+    .map((key) => `${key}=${obj[key]}`)
+    .join(',');
+
+
+internals.values = {
+    ops_requests: (event) => {
+        const requests = Hoek.reach(event, 'load.requests');
+        if (Object.keys(requests).length === 0) {
+            return null;
+        }
+        return Object.keys(requests).map((port) => {
+            const statusCodesValues = {};
+            Object.keys(requests[port].statusCodes).map((code) => {
+                const key = 'requests' + code;
+                statusCodesValues[key] = requests[port].statusCodes[code];
+                return null;
+            });
+            const tags = {
+                'port': port
+            };
+            const fields = Object.assign({
+                'requestsTotal': requests[port].total,
+                'requestsDisconnects': requests[port].disconnects
+            },statusCodesValues);
+
+            return {
+                'tags': tags,
+                'fields': fields
+            };
+        });
+    },
+    ops_concurrents: (event) => {
+        const concurrents = Hoek.reach(event, 'load.concurrents');
+        if (Object.keys(concurrents).length === 0) {
+            return null;
+        }
+
+        return Object.keys(concurrents).map((port) => {
+            return {
+                'tags' : {
+                    'port': port
+                },
+                'fields' : {
+                    'concurrents': concurrents[port]
+                }
+            };
+        });
+    },
+    ops_responseTimes: (event) => {
+        const responseTimes = Hoek.reach(event, 'load.responseTimes');
+        if (Object.keys(responseTimes).length === 0) {
+            return null;
+        }
+        return Object.keys(responseTimes).map((port) => {
+            const stats = {};
+            Object.keys(responseTimes[port]).forEach((aggregator) => {
+                stats[aggregator] = isNaN(responseTimes[port][aggregator]) || (responseTimes[port][aggregator] === null) ? 0 : responseTimes[port][aggregator];
+            });
+            const tags = {
+                'port': port
+            };
+            return {
+                'tags': tags,
+                'fields': stats
+            };
+        });
+    },
+    ops_sockets: (event) => {
+        const sockets = Hoek.reach(event, 'load.sockets');
+        if (Object.keys(sockets).length === 0) {
+            return null;
+        }
+        let socketsValues = {
+            'tags': {},
+            'fields': {}
+        };
+        Object.keys(sockets).forEach((protocol) => {
+            const key = protocol + 'Total';
+            socketsValues.fields[key] = sockets[protocol].total;
+        });
+        return [socketsValues];
+    }
+};
+
+const opsFormat = function (event, config) {
+    const timestamp = event.timestamp;
+    const tags = internals.serialize(internals.tags(event));
+
+    let loadValues = [];
+    const requests = internals.values.ops_requests(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_requests',timestamp,tags,requests,config));
+
+    const concurrents = internals.values.ops_concurrents(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_concurrents',timestamp,tags,concurrents,config));
+
+    const responseTimes = internals.values.ops_responseTimes(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_responseTimes',timestamp,tags,responseTimes,config));
+
+    const sockets = internals.values.ops_sockets(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_sockets',timestamp,tags,sockets,config));
+    return loadValues;
+}
+
+const opsFormatHelper = function (eventName, timestamp, tags, eventValues, config) {
+    if (eventValues !== null) {
+        const finalEventValues = eventValues.map((value) => {
+            if (config.metadata) {
+                Object.keys(config.metadata).forEach( (key) => {
+                    value.fields[key] = internals.String(config.metadata[key]);
+                });
+            }
+
+            let finalTags = '';
+            const fields = internals.serialize(value.fields);
+            if (value.tags && Object.keys(value.tags).length > 0) {
+                const eventTags = internals.serialize(value.tags);
+                finalTags = [tags,eventTags].join(',');
+            } else {
+                finalTags = tags;
+            }
+            // Timestamp in InfluxDB is in nanoseconds
+            return `${eventName},${finalTags} ${fields} ${timestamp}000000`;
+        });
+        return finalEventValues;
+    }
+    return [];
+};
+
+module.exports.format = (event, config) => {
+    return opsFormat(event,config);
+};

--- a/lib/ops-format.js
+++ b/lib/ops-format.js
@@ -2,7 +2,7 @@
 // Load modules
 
 const Os = require('os');
-const Qs = require('querystring');
+const Querystring = require('querystring');
 const Url = require('url');
 const Hoek = require('hoek');
 const Stringify = require('fast-safe-stringify');
@@ -14,7 +14,14 @@ const internals = {
 };
 
 /* eslint-disable no-confusing-arrow */
-internals.Int = (value) => isNaN(Number(value)) ? value : String(value) + 'i';
+//internals.Int = (value) => isNaN(Number(value)) ? value : String(value) + 'i';
+internals.Int = function(value) {
+  if (isNaN(Number(value))) {
+        return value;
+    } else {
+        return `${String(value)}i`;
+    }
+};
 
 internals.String = (value) => {
     let string;
@@ -31,16 +38,21 @@ internals.String = (value) => {
 };
 
 internals.tags = (event) => {
-
     return {
         host : event.host || internals.host,
         pid  : event.pid
     };
 };
 
-internals.serialize = (obj) => Object.keys(obj)
+//internals.serialize = (obj) => Object.keys(obj)
+//    .map((key) => `${key}=${obj[key]}`)
+//    .join(',');
+
+internals.serialize = function(obj) {
+  return Object.keys(obj)
     .map((key) => `${key}=${obj[key]}`)
-    .join(',');
+    .join(',')
+};
 
 const opsRequests = (event) => {
     const requests = Hoek.reach(event, 'load.requests');

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-hapi": "^4.0.0",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.1",
-    "lab": "10.x.x"
+    "lab": "^10.9.0"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-hapi": "^4.0.0",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.1",
-    "lab": "^10.9.0"
+    "lab": "10.x.x"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,7 +42,10 @@ const testEvent = {
     }
 };
 /* eslint max-len: ["error", 440, 4] */
-const expectedMessage = 'ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192,testing="superClutch" 123456789000000';
+const expectedMessage = [
+    'ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192,testing="superClutch" 123456789000000',
+    'ops_concurrents,host=mytesthost,pid=9876 port=8080,concurrents=0,testing="superClutch" 123456789000000'
+].join('\n');
 
 const mocks = {
     readStream() {
@@ -69,7 +72,7 @@ const mocks = {
             req.on('end', () => {
                 hitCount += 1;
                 const dataRows = data.split('\n');
-
+                console.log(dataRows.length);
                 // Because threshold is 5, expect 5 events to be sent at a time
                 expect(dataRows.length).to.equal(5);
                 dataRows.forEach((datum) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,7 +72,6 @@ const mocks = {
             req.on('end', () => {
                 hitCount += 1;
                 const dataRows = data.split('\n');
-                console.log(dataRows.length);
                 // Because threshold is 5, expect 5 events to be sent at a time
                 expect(dataRows.length).to.equal(5);
                 dataRows.forEach((datum) => {

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -12,20 +12,25 @@ const expect = Code.expect;
 
 const testHost = 'myservice.awesome.com';
 
+
 const getExpectedMessage = (ports, metadata) => {
     const plusMetadata = metadata || '';
     /* eslint max-len: ["error", 440, 4] */
     const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
     const eventHost = 'host=myservice.awesome.com,pid=9876';
-    const loadOpsEvents = ports.map((port) => {
-        return [
-            `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`,
-            `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`,
-            `ops_responseTimes,${eventHost},port=${port} avg=990,max=1234 1485996802647000000`,
-            `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`
-        ].join('\n');
-    });
-    return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');
+    const loadOpsRequestsEvents = ports.map((port) => {
+        return `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`;
+    }).join('\n');
+    const loadOpsConcurrentsEvents = ports.map((port) => {
+        return `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`;
+    }).join('\n');
+    const loadOpsResponseTimesEvents = ports.map((port) => {
+        return `ops_responseTimes,${eventHost},port=${port} avg=990,max=1234 1485996802647000000`;
+    }).join('\n');
+    const loadOpsSocketsEvents = `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`;
+    const finalOpsEvents = [loadOpsRequestsEvents, loadOpsConcurrentsEvents, loadOpsResponseTimesEvents, loadOpsSocketsEvents];
+
+    return expectedBaseMessage + '\n' + finalOpsEvents.join('\n');
 };
 
 const testOpsEventBase = JSON.stringify({
@@ -53,54 +58,6 @@ const testOpsEventBase = JSON.stringify({
     }
 });
 
-const get2PortsExpectedMessage = (ports, metadata) => {
-    const plusMetadata = metadata || '';
-    /* eslint max-len: ["error", 440, 4] */
-    const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
-    const eventHost = 'host=myservice.awesome.com,pid=9876';
-    const loadOpsRequestsEvents = ports.map((port) => {
-        return `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`;
-    }).join('\n');
-    const loadOpsConcurrentsEvents = ports.map((port) => {
-        return `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`;
-    }).join('\n');
-    const loadOpsResponseTimesEvents = ports.map((port) => {
-        return `ops_responseTimes,${eventHost},port=${port} avg=990,max=1234 1485996802647000000`;
-    }).join('\n');
-    const loadOpsSocketsEvents = `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`;
-    const finalOpsEvents = [loadOpsRequestsEvents, loadOpsConcurrentsEvents, loadOpsResponseTimesEvents, loadOpsSocketsEvents];
-
-    return expectedBaseMessage + '\n' + finalOpsEvents.join('\n');
-};
-
-const testOpsEvent2PortsBase = JSON.stringify({
-    event: 'ops',
-    timestamp: 1485996802647,
-    host: testHost,
-    pid: 9876,
-    os: {
-        load: [3.05078125, 2.11279296875, 1.625],
-        mem: { total: 6089818112, free: 147881984 },
-        uptime: 23489
-    },
-    proc: {
-        uptime: 22.878,
-        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
-        delay: 32.29
-    },
-    load: {
-        requests: { '8080':
-            { total: 94, disconnects: 1, statusCodes: { '200': 61 } },
-            '8081':
-            { total: 94, disconnects: 1, statusCodes: { '200': 61 } },
-        },
-        concurrents: { '8080': 23, '8081': 23 },
-        responseTimes: { '8080': { avg: 990, max: 1234 }, '8081': { avg: 990, max: 1234 } },
-        sockets: { http: { total: 19 }, https: { total: 49 } }
-    }
-});
-
-
 const getOpsResponseTimesExpectedMessage = (ports, metadata) => {
     const plusMetadata = metadata || '';
     /* eslint max-len: ["error", 440, 4] */
@@ -116,31 +73,6 @@ const getOpsResponseTimesExpectedMessage = (ports, metadata) => {
     });
     return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');
 };
-
-const testOpsResponseTimesEventBase = JSON.stringify({
-    event: 'ops',
-    timestamp: 1485996802647,
-    host: testHost,
-    pid: 9876,
-    os: {
-        load: [3.05078125, 2.11279296875, 1.625],
-        mem: { total: 6089818112, free: 147881984 },
-        uptime: 23489
-    },
-    proc: {
-        uptime: 22.878,
-        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
-        delay: 32.29
-    },
-    load: {
-        requests: { '8080':
-            { total: 94, disconnects: 1, statusCodes: { '200': 61 } }
-        },
-        concurrents: { '8080': 23 },
-        responseTimes: { '8080': { avg: null, max: 'abc' } },
-        sockets: { http: { total: 19 }, https: { total: 49 } }
-    }
-});
 
 const getOpsResponseTimes2ExpectedMessage = (ports, metadata) => {
     const plusMetadata = metadata || '';
@@ -158,31 +90,6 @@ const getOpsResponseTimes2ExpectedMessage = (ports, metadata) => {
     return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');
 };
 
-const testOpsResponseTimes2EventBase = JSON.stringify({
-    event: 'ops',
-    timestamp: 1485996802647,
-    host: testHost,
-    pid: 9876,
-    os: {
-        load: [3.05078125, 2.11279296875, 1.625],
-        mem: { total: 6089818112, free: 147881984 },
-        uptime: 23489
-    },
-    proc: {
-        uptime: 22.878,
-        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
-        delay: 32.29
-    },
-    load: {
-        requests: { '8080':
-            { total: 94, disconnects: 1, statusCodes: { '200': 61 } }
-        },
-        concurrents: { '8080': 23 },
-        responseTimes: { '8080': { avg: 123, max: '456' } },
-        sockets: { http: { total: 19 }, https: { total: 49 } }
-    }
-});
-
 describe('ops', () => {
     it('One port => two events created', (done) => {
         const testEvent = JSON.parse(testOpsEventBase);
@@ -190,29 +97,30 @@ describe('ops', () => {
         expect(formattedEvent).to.equal(getExpectedMessage(['8080']));
         done();
     });
-});
-
-describe('ops', () => {
     it('Two ports => two events created', (done) => {
-        const testEvent = JSON.parse(testOpsEvent2PortsBase);
+        let testEvent = JSON.parse(testOpsEventBase);
+        testEvent.load.requests['8081'] = testEvent.load.requests['8080'];
+        testEvent.load.concurrents['8081'] = testEvent.load.concurrents['8080'];
+        testEvent.load.responseTimes['8081'] = testEvent.load.responseTimes['8080'];
         const formattedEvent = LineProtocol.format(testEvent, {});
-        expect(formattedEvent).to.equal(get2PortsExpectedMessage(['8080','8081']));
+        expect(formattedEvent).to.equal(getExpectedMessage(['8080','8081']));
         done();
     });
 });
 
 describe('ops_responseTimes avg max', () => {
     it('avg is null and max is string => avg and max shall be 0s', (done) => {
-        const testEvent = JSON.parse(testOpsResponseTimesEventBase);
+        const testEvent = JSON.parse(testOpsEventBase);
+        testEvent.load.responseTimes['8080'].avg = null;
+        testEvent.load.responseTimes['8080'].max = 'abc';
         const formattedEvent = LineProtocol.format(testEvent, {});
         expect(formattedEvent).to.equal(getOpsResponseTimesExpectedMessage(['8080']));
         done();
     });
-});
-
-describe('ops_responseTimes avg max', () => {
     it('avg and max are both numbers => avg and max shall be numbers', (done) => {
-        const testEvent = JSON.parse(testOpsResponseTimes2EventBase);
+        let testEvent = JSON.parse(testOpsEventBase);
+        testEvent.load.responseTimes['8080'].avg = 123;
+        testEvent.load.responseTimes['8080'].max = '456';
         const formattedEvent = LineProtocol.format(testEvent, {});
         expect(formattedEvent).to.equal(getOpsResponseTimes2ExpectedMessage(['8080']));
         done();

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -63,7 +63,7 @@ describe('ops', () => {
 });
 
 describe('log', () => {
-    it('Event is formatted as expected', (done) => {
+    it('Event log is formatted as expected', (done) => {
         const testEvent = {
             event: 'log',
             host: 'mytesthost',
@@ -74,6 +74,82 @@ describe('log', () => {
         };
         const formattedLogEvent = LineProtocol.format(testEvent, {});
         const expectedLogEvent = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
+        expect(formattedLogEvent).to.equal(expectedLogEvent);
+        done();
+    });
+});
+
+describe('request', () => {
+    it('Event request is formatted as expected', (done) => {
+        const testEvent = {
+            event: 'request',
+            host: 'mytesthost',
+            timestamp: 1485996802647,
+            data: 'userid=001',
+            id: '4321',
+            path: '/hello',
+            method: 'POST',
+            tags: ['request','blahblahblah'],
+            pid: 1234
+        };
+        const formattedLogEvent = LineProtocol.format(testEvent, {});
+        const expectedLogEvent = 'request,host=mytesthost,pid=1234 data="userid=001",id="4321",method="POST",path="/hello",tags="request,blahblahblah" 1485996802647000000';
+        expect(formattedLogEvent).to.equal(expectedLogEvent);
+        done();
+    });
+});
+
+
+describe('response', () => {
+    it('Event response is formatted as expected', (done) => {
+        const testEvent = {
+            event: 'response',
+            host: 'mytesthost',
+            timestamp: 1485996802647,
+            httpVersion   : '1.1',
+            id            : '1234',
+            instance      : 'mytesthost',
+            labels        : 'label001',
+            method        : 'GET',
+            path          : '/hello',
+            source : {
+                referer       : 'referer',
+                remoteAddress : '127.0.0.1',
+                userAgent     : 'Chrome'
+            },
+            query : {
+                k1: 'v1', k2: 'v2'
+            },
+            responseTime  : 500,
+            statusCode    : 200,
+            pid           : 1234
+        };
+        const formattedLogEvent = LineProtocol.format(testEvent, {});
+        const expectedLogEvent = 'response,host=mytesthost,pid=1234 httpVersion="1.1",id="1234",instance="mytesthost",labels="label001",method="GET",path="/hello",query="k1=v1&k2=v2",referer="referer",remoteAddress="127.0.0.1",responseTime=500i,statusCode=200i,userAgent="Chrome" 1485996802647000000';
+        expect(formattedLogEvent).to.equal(expectedLogEvent);
+        done();
+    });
+});
+
+describe('error', () => {
+    it('Event error is formatted as expected', (done) => {
+        const testEvent = {
+            event: 'error',
+            host: 'mytesthost',
+            timestamp: 1485996802647,
+            error : {
+                name   : 'error1',
+                message : 'this is an error msg',
+                stack  : 'stackoverflow'
+            },
+            id     : '1234',
+            url    : '/hello',
+            method : 'GET',
+            tags   : ['error','crash'],
+            pid: 1234
+        };
+        const formattedLogEvent = LineProtocol.format(testEvent, {});
+        const expectedLogEvent = 'error,host=mytesthost,pid=1234 error.name="error1",error.message="this is an error msg",error.stack="stackoverflow",id="1234",url="/hello",method="GET",tags="error,crash" 1485996802647000000';
         expect(formattedLogEvent).to.equal(expectedLogEvent);
         done();
     });

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const lineProtocol = require('../lib/line-protocol')
+
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+const testHost = 'myservice.awesome.com'
+
+function getExpectedMessage(ports, metadata) {
+    const plusMetadata = metadata || '';
+    /* eslint max-len: ["error", 440, 4] */
+    const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
+    const eventHost = 'host=myservice.awesome.com,pid=128'
+    const loadOpsEvents = ports.map((port) => {
+        return [
+            `ops_requests,${eventHost} port=${port},requestsTotal=1,requestsDisconnects=1,requests200=61`,
+            `ops_concurrents,${eventHost} port=${port},concurrents=23`,
+            `ops_responseTimes,${eventHost} port=${port},avg=990,max=1234`,
+            `ops_sockets,${eventHost} port=${port},httpTotal=19,httpsTotal=49`
+        ].join('\n');
+    });
+    return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');
+}
+
+const testEventBase = JSON.stringify({
+    event: 'ops',
+    timestamp: 1485996802647,
+    host: testHost,
+    pid: 9876,
+    os: {
+        load: [ 3.05078125, 2.11279296875, 1.625 ],
+        mem: { total: 6089818112, free: 147881984 },
+        uptime: 23489
+    },
+    proc: {
+        uptime: 22.878,
+        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
+        delay: 32.29
+    },
+    load: {
+        requests: { '8080':
+            { total: 94, disconnects: 1, statusCodes: { '200': 61 } }
+        },
+        concurrents: { '8080': 23 },
+        responseTimes: { '8080': { avg: 990, max: 1234 } },
+        sockets: { http: { total: 19 }, https: { total: 49 } }
+    }
+});
+
+describe('ops', () => {
+    it('One port => two events created', (done) => {
+        const testEvent = JSON.parse(testEventBase);
+        const formattedEvent = lineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(getExpectedMessage(['8080']));
+    });
+})

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -53,11 +53,168 @@ const testOpsEventBase = JSON.stringify({
     }
 });
 
+const get2PortsExpectedMessage = (ports, metadata) => {
+    const plusMetadata = metadata || '';
+    /* eslint max-len: ["error", 440, 4] */
+    const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
+    const eventHost = 'host=myservice.awesome.com,pid=9876';
+    const loadOpsRequestsEvents = ports.map((port) => {
+        return `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`;
+    }).join('\n');
+    const loadOpsConcurrentsEvents = ports.map((port) => {
+        return `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`;
+    }).join('\n');
+    const loadOpsResponseTimesEvents = ports.map((port) => {
+        return `ops_responseTimes,${eventHost},port=${port} avg=990,max=1234 1485996802647000000`;
+    }).join('\n');
+    const loadOpsSocketsEvents = `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`;
+    const finalOpsEvents = [loadOpsRequestsEvents, loadOpsConcurrentsEvents, loadOpsResponseTimesEvents, loadOpsSocketsEvents];
+
+    return expectedBaseMessage + '\n' + finalOpsEvents.join('\n');
+};
+
+const testOpsEvent2PortsBase = JSON.stringify({
+    event: 'ops',
+    timestamp: 1485996802647,
+    host: testHost,
+    pid: 9876,
+    os: {
+        load: [3.05078125, 2.11279296875, 1.625],
+        mem: { total: 6089818112, free: 147881984 },
+        uptime: 23489
+    },
+    proc: {
+        uptime: 22.878,
+        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
+        delay: 32.29
+    },
+    load: {
+        requests: { '8080':
+            { total: 94, disconnects: 1, statusCodes: { '200': 61 } },
+            '8081':
+            { total: 94, disconnects: 1, statusCodes: { '200': 61 } },
+        },
+        concurrents: { '8080': 23, '8081': 23 },
+        responseTimes: { '8080': { avg: 990, max: 1234 }, '8081': { avg: 990, max: 1234 } },
+        sockets: { http: { total: 19 }, https: { total: 49 } }
+    }
+});
+
+
+const getOpsResponseTimesExpectedMessage = (ports, metadata) => {
+    const plusMetadata = metadata || '';
+    /* eslint max-len: ["error", 440, 4] */
+    const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
+    const eventHost = 'host=myservice.awesome.com,pid=9876';
+    const loadOpsEvents = ports.map((port) => {
+        return [
+            `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`,
+            `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`,
+            `ops_responseTimes,${eventHost},port=${port} avg=0,max=0 1485996802647000000`,
+            `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`
+        ].join('\n');
+    });
+    return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');
+};
+
+const testOpsResponseTimesEventBase = JSON.stringify({
+    event: 'ops',
+    timestamp: 1485996802647,
+    host: testHost,
+    pid: 9876,
+    os: {
+        load: [3.05078125, 2.11279296875, 1.625],
+        mem: { total: 6089818112, free: 147881984 },
+        uptime: 23489
+    },
+    proc: {
+        uptime: 22.878,
+        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
+        delay: 32.29
+    },
+    load: {
+        requests: { '8080':
+            { total: 94, disconnects: 1, statusCodes: { '200': 61 } }
+        },
+        concurrents: { '8080': 23 },
+        responseTimes: { '8080': { avg: null, max: 'abc' } },
+        sockets: { http: { total: 19 }, https: { total: 49 } }
+    }
+});
+
+const getOpsResponseTimes2ExpectedMessage = (ports, metadata) => {
+    const plusMetadata = metadata || '';
+    /* eslint max-len: ["error", 440, 4] */
+    const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
+    const eventHost = 'host=myservice.awesome.com,pid=9876';
+    const loadOpsEvents = ports.map((port) => {
+        return [
+            `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`,
+            `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`,
+            `ops_responseTimes,${eventHost},port=${port} avg=123,max=456 1485996802647000000`,
+            `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`
+        ].join('\n');
+    });
+    return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');
+};
+
+const testOpsResponseTimes2EventBase = JSON.stringify({
+    event: 'ops',
+    timestamp: 1485996802647,
+    host: testHost,
+    pid: 9876,
+    os: {
+        load: [3.05078125, 2.11279296875, 1.625],
+        mem: { total: 6089818112, free: 147881984 },
+        uptime: 23489
+    },
+    proc: {
+        uptime: 22.878,
+        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
+        delay: 32.29
+    },
+    load: {
+        requests: { '8080':
+            { total: 94, disconnects: 1, statusCodes: { '200': 61 } }
+        },
+        concurrents: { '8080': 23 },
+        responseTimes: { '8080': { avg: 123, max: '456' } },
+        sockets: { http: { total: 19 }, https: { total: 49 } }
+    }
+});
+
 describe('ops', () => {
     it('One port => two events created', (done) => {
         const testEvent = JSON.parse(testOpsEventBase);
         const formattedEvent = LineProtocol.format(testEvent, {});
         expect(formattedEvent).to.equal(getExpectedMessage(['8080']));
+        done();
+    });
+});
+
+describe('ops', () => {
+    it('Two ports => two events created', (done) => {
+        const testEvent = JSON.parse(testOpsEvent2PortsBase);
+        const formattedEvent = LineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(get2PortsExpectedMessage(['8080','8081']));
+        done();
+    });
+});
+
+describe('ops_responseTimes avg max', () => {
+    it('avg is null and max is string => avg and max shall be 0s', (done) => {
+        const testEvent = JSON.parse(testOpsResponseTimesEventBase);
+        const formattedEvent = LineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(getOpsResponseTimesExpectedMessage(['8080']));
+        done();
+    });
+});
+
+describe('ops_responseTimes avg max', () => {
+    it('avg and max are both numbers => avg and max shall be numbers', (done) => {
+        const testEvent = JSON.parse(testOpsResponseTimes2EventBase);
+        const formattedEvent = LineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(getOpsResponseTimes2ExpectedMessage(['8080']));
         done();
     });
 });

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -16,13 +16,13 @@ const getExpectedMessage = (ports, metadata) => {
     const plusMetadata = metadata || '';
     /* eslint max-len: ["error", 440, 4] */
     const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
-    const eventHost = 'host=myservice.awesome.com,pid=128';
+    const eventHost = 'host=myservice.awesome.com,pid=9876';
     const loadOpsEvents = ports.map((port) => {
         return [
-            `ops_requests,${eventHost} port=${port},requestsTotal=1,requestsDisconnects=1,requests200=61`,
-            `ops_concurrents,${eventHost} port=${port},concurrents=23`,
-            `ops_responseTimes,${eventHost} port=${port},avg=990,max=1234`,
-            `ops_sockets,${eventHost} port=${port},httpTotal=19,httpsTotal=49`
+            `ops_requests,${eventHost} port=${port},requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`,
+            `ops_concurrents,${eventHost} port=${port},concurrents=23 1485996802647000000`,
+            `ops_responseTimes,${eventHost} port=${port},avg=990,max=1234 1485996802647000000`,
+            `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`
         ].join('\n');
     });
     return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -62,7 +62,7 @@ describe('ops', () => {
     });
 });
 
-describe('response', () => {
+describe('log', () => {
     it('Event is formatted as expected', (done) => {
         const testEvent = {
             event: 'log',

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -19,9 +19,9 @@ const getExpectedMessage = (ports, metadata) => {
     const eventHost = 'host=myservice.awesome.com,pid=9876';
     const loadOpsEvents = ports.map((port) => {
         return [
-            `ops_requests,${eventHost} port=${port},requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`,
-            `ops_concurrents,${eventHost} port=${port},concurrents=23 1485996802647000000`,
-            `ops_responseTimes,${eventHost} port=${port},avg=990,max=1234 1485996802647000000`,
+            `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`,
+            `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`,
+            `ops_responseTimes,${eventHost},port=${port} avg=990,max=1234 1485996802647000000`,
             `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`
         ].join('\n');
     });

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -58,7 +58,7 @@ const testOpsEventBase = JSON.stringify({
     }
 });
 
-const getOpsResponseTimesExpectedMessage = (ports, metadata) => {
+const getOpsResponseTimesExpectedMessage = (ports, metadata, avg, max) => {
     const plusMetadata = metadata || '';
     /* eslint max-len: ["error", 440, 4] */
     const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
@@ -67,23 +67,7 @@ const getOpsResponseTimesExpectedMessage = (ports, metadata) => {
         return [
             `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`,
             `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`,
-            `ops_responseTimes,${eventHost},port=${port} avg=0,max=0 1485996802647000000`,
-            `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`
-        ].join('\n');
-    });
-    return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');
-};
-
-const getOpsResponseTimes2ExpectedMessage = (ports, metadata) => {
-    const plusMetadata = metadata || '';
-    /* eslint max-len: ["error", 440, 4] */
-    const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
-    const eventHost = 'host=myservice.awesome.com,pid=9876';
-    const loadOpsEvents = ports.map((port) => {
-        return [
-            `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`,
-            `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`,
-            `ops_responseTimes,${eventHost},port=${port} avg=123,max=456 1485996802647000000`,
+            `ops_responseTimes,${eventHost},port=${port} avg=${avg},max=${max} 1485996802647000000`,
             `ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`
         ].join('\n');
     });
@@ -114,7 +98,7 @@ describe('ops_responseTimes avg max', () => {
         testEvent.load.responseTimes['8080'].avg = null;
         testEvent.load.responseTimes['8080'].max = 'abc';
         const formattedEvent = LineProtocol.format(testEvent, {});
-        expect(formattedEvent).to.equal(getOpsResponseTimesExpectedMessage(['8080']));
+        expect(formattedEvent).to.equal(getOpsResponseTimesExpectedMessage(['8080'],null,0,0));
         done();
     });
     it('avg and max are both numbers => avg and max shall be numbers', (done) => {
@@ -122,7 +106,7 @@ describe('ops_responseTimes avg max', () => {
         testEvent.load.responseTimes['8080'].avg = 123;
         testEvent.load.responseTimes['8080'].max = '456';
         const formattedEvent = LineProtocol.format(testEvent, {});
-        expect(formattedEvent).to.equal(getOpsResponseTimes2ExpectedMessage(['8080']));
+        expect(formattedEvent).to.equal(getOpsResponseTimesExpectedMessage(['8080'],null,123,456));
         done();
     });
 });


### PR DESCRIPTION
send metrics of `ops_requests`, `ops_responseTimes`, `ops_concurrents` and `ops_sockets` derived from event `ops`