### PR TITLE
Include Load Data from Ops in Influx Events Take II

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-/node_modules
-.DS_Store
-coverage.html
+node_modules/*
+
+# Index files added by text editors and IDE's should be ignored.
+.idea
+.idea/*
+*.DS_Store
+
+# Not using npm v5 functionality just yet, may revisit in the future.
 package-lock.json
+coverage.html
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ _Standard tags: host,pid, metadata (optional)_
 
 event             | numEvents | tags       | fields
 ------------------|-----------|------------|------------------------------------------
-ops               | 1         | _Standard_ | os.cpu1m,os.cpu5m,os.cpu15m,os.freemem,os.totalmem,os.uptime,os.totalmem,proc.delay,proc.heapTotal,proc.heapUsed,proc.rss,proc.uptime
-ops_requests      | 1 per port|_Standard_ + port| requestsTotal,requestsDisconnects,requests200* -- one field for each status code
+ops               | 1         | _Standard_ | os.cpu1m, os.cpu5m, os.cpu15m, os.freemem, os.totalmem, os.uptime, os.totalmem, proc.delay, proc.heapTotal, proc.heapUsed, proc.rss, proc.uptime
+ops_requests      | 1 per port|_Standard_ + port| requestsTotal, requestsDisconnects, requests200* -- one field for each status code
 ops_concurrents   | 1 per port|_Standard_ + port| concurrents
 ops_responseTimes | 1 per port|_Standard_ + port| avg, max
-ops_sockets       | 1         |_Standard_| httpTotal,httpsTotal
+ops_sockets       | 1         |_Standard_| httpTotal, httpsTotal
 
 ### Request
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Creates a new GoodInflux object where:
   - `[wreck]` - configuration object to pass into [`wreck`](https://github.com/hapijs/wreck#advanced). Defaults to `{ timeout: 60000, headers: {} }`. `content-type` is always "text/plain".
   - `[udpType]` - UDP type; defaults to `udp4`. Probably not necessary to change, but more documentation is available on the [NodeJS Dgram Documentation](https://nodejs.org/api/dgram.html#dgram_dgram_createsocket_type_callback)
   - `[metadata]` - arbitrary information you would like to add to your InfluxDB stats.  This helps you query InfluxDB for the statistics you want.
-    - *Note: Currently added to the fields, which is not really a correct usage of InfluxDB. We may move this info to the tags in a future release.*
 
 ## Series
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ const options = {
             args: ['http://localhost:8086/write?db=good', {
                 threshold: 10,
                 metadata: {
-                    serviceName: 'SuperAwesomeService'
+                    serviceName: 'SuperAwesomeService',
+                    dataCenter: 'Banff'
                 }
         	}]
         }]
@@ -68,7 +69,7 @@ Creates a new GoodInflux object where:
 - `endpoint` - full path to remote server's InfluxDB HTTP API end point to transmit InfluxDB statistics (e.g. `http://localhost:8086/write?db=good`)
 - `config` - configuration object *(Optional)*
   - `[threshold]` - number of events to hold before transmission. Defaults to `5`. Set to `0` to have every event start transmission instantly.
-    - *Note that threshold above `5` will be set to `5`.  Why?  Because if UDP packets get too big they fail to transmit.*
+    - *Note that for UDP, threshold above `5` will be set to `5`.  Why?  Because if UDP packets get too big they fail to transmit.*
   - `[errorThreshold]` - number of erroring message sends to tolerate before the plugin fails.  Default is 0.
   - `[wreck]` - configuration object to pass into [`wreck`](https://github.com/hapijs/wreck#advanced). Defaults to `{ timeout: 60000, headers: {} }`. `content-type` is always "text/plain".
   - `[udpType]` - UDP type; defaults to `udp4`. Probably not necessary to change, but more documentation is available on the [NodeJS Dgram Documentation](https://nodejs.org/api/dgram.html#dgram_dgram_createsocket_type_callback)
@@ -93,25 +94,13 @@ Each Ops event from the Hapi Good plugin is separated out into 5 events for Infl
 
 _Standard tags: host,pid, metadata (optional)_
 
-event             | numEvents | tags     | fields                                   |
-------------------|-----------|----------|------------------------------------------|
-ops               | 1         |_Standard_| os.cpu1m,os.cpu5m,os.cpu15m,os.freemem,  |
-                  |           |          | os.totalmem,os.uptime,os.totalmem,       |
-                  |           |          | proc.delay,proc.heapTotal,proc.heapUsed, |
-                  |           |          | proc.rss,proc.uptime                     |
-------------------|-----------|----------|------------------------------------------|
-ops_requests      | 1 per     |_Standard_| requestsTotal,requestsDisconnects,       |
-                  | port      | + port   | requests200*                             |
-                  |           |          |   * One field for each status code       |
-------------------|-----------|----------|------------------------------------------|
-ops_concurrents   | 1 per     |_Standard_| concurrents                              |
-                  | port      | + port   |                                          |
-------------------|-----------|----------|------------------------------------------|
-ops_responseTimes | 1 per     |_Standard_| avg, max                                 |
-                  | port      | + port   |                                          |
-------------------|-----------|----------|------------------------------------------|
-ops_sockets       | 1         |_Standard_| httpTotal,httpsTotal                     |
-------------------|-----------|----------|------------------------------------------|
+event             | numEvents | tags       | fields
+------------------|-----------|------------|------------------------------------------
+ops               | 1         | _Standard_ | os.cpu1m,os.cpu5m,os.cpu15m,os.freemem,os.totalmem,os.uptime,os.totalmem,proc.delay,proc.heapTotal,proc.heapUsed,proc.rss,proc.uptime
+ops_requests      | 1 per port|_Standard_ + port| requestsTotal,requestsDisconnects,requests200* -- one field for each status code
+ops_concurrents   | 1 per port|_Standard_ + port| concurrents
+ops_responseTimes | 1 per port|_Standard_ + port| avg, max
+ops_sockets       | 1         |_Standard_| httpTotal,httpsTotal
 
 ### Request
 

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -3,14 +3,14 @@
 const Os = require('os');
 const Stringify = require('fast-safe-stringify');
 
-const Int = (value) => {
+const influxInt = (value) => {
     if (Number.isInteger(Number(value))) {
         return `${String(value)}i`;
     }
     return value;
 };
 
-const formattedString = (value) => {
+const formatString = (value) => {
     let string;
 
     if (Object.prototype.toString.call(value) === '[object Object]' &&
@@ -50,8 +50,8 @@ const serialize = (obj) => {
 
 module.exports = {
     host: Os.hostname(),
-    Int,
-    String: formattedString,
+    Int: influxInt,
+    String: formatString,
     tags,
     serialize
 };

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -26,7 +26,7 @@ const formatString = (value) => {
 
 const tags = (config, event) => {
 
-    const tags = {
+    const completeTags = {
         host: event.host || Os.hostname(),
         pid: event.pid
     };
@@ -34,12 +34,12 @@ const tags = (config, event) => {
     if (config.metadata) {
         Object.keys(config.metadata).forEach((key) => {
             if (config.metadata[key] !== undefined && config.metadata[key] !== null) {
-                tags[key] = Formatters.String(config.metadata[key]);
+                completeTags[key] = formatString(config.metadata[key]);
             }
         });
     }
 
-    return tags;
+    return completeTags;
 };
 
 const serialize = (obj) => {

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -27,7 +27,7 @@ const formatString = (value) => {
 const tags = (config, event) => {
 
     const tags = {
-        host: event.host || internals.host,
+        host: event.host || Os.hostname(),
         pid: event.pid
     };
 
@@ -49,7 +49,6 @@ const serialize = (obj) => {
 };
 
 module.exports = {
-    host: Os.hostname(),
     Int: influxInt,
     String: formatString,
     tags,

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const Os = require('os');
+const Stringify = require('fast-safe-stringify');
+
+const Int = (value) => {
+    if (Number.isInteger(Number(value))) {
+        return `${String(value)}i`;
+    }
+    return value;
+};
+
+const formattedString = (value) => {
+    let string;
+
+    if (Object.prototype.toString.call(value) === '[object Object]' &&
+        !Array.isArray(value)) {
+        string = Stringify(value).replace(/"/g, '\\"');
+    }
+    else {
+        string = String(value);
+    }
+
+    return `"${string}"`;
+};
+
+const tags = (config, event) => {
+
+    const tags = {
+        host: event.host || internals.host,
+        pid: event.pid
+    };
+
+    if (config.metadata) {
+        Object.keys(config.metadata).forEach((key) => {
+            if (config.metadata[key] !== undefined && config.metadata[key] !== null) {
+                tags[key] = Formatters.String(config.metadata[key]);
+            }
+        });
+    }
+
+    return tags;
+};
+
+const serialize = (obj) => {
+    return Object.keys(obj)
+        .map((key) => `${key}=${obj[key]}`)
+        .join(',');
+};
+
+module.exports = {
+    host: Os.hostname(),
+    Int,
+    String: formattedString,
+    tags,
+    serialize
+};

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -12,6 +12,7 @@ const internals = {
 
 class GoodInfluxUdp extends GoodUdp {
     constructor(endpoint, config) {
+        // Limit threshold for UDP protocol to avoid transmission errors
         if (isNaN(config.threshold) || config.threshold > 5) {
             config.threshold = 5;
         }

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -12,6 +12,9 @@ const internals = {
 
 class GoodInfluxUdp extends GoodUdp {
     constructor(endpoint, config) {
+        if (isNaN(config.threshold) || config.threshold > 5) {
+            config.threshold = 5;
+        }
         super(endpoint, config);
         this._settings.schema = 'good-influx';
         this.config = Hoek.applyToDefaults(internals.defaults, config);

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -156,7 +156,7 @@ internals.values = {
             labels: internals.String(event.labels),
             method: internals.String(event.method && event.method.toUpperCase()),
             path: internals.String(event.path),
-            query: Qs.stringify(internals.String(event.query)),
+            query: internals.String(Qs.stringify(event.query)),
             referer: internals.String(Hoek.reach(event, 'source.referer')),
             remoteAddress: internals.String(Hoek.reach(event, 'source.remoteAddress')),
             responseTime: internals.Int(event.responseTime),

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -137,12 +137,10 @@ module.exports.format = (event, config) => {
     }
 
     // Tag set
-    const tags = internals.serialize(internals.tags(config, event));
+    const tags = Formatters.serialize(Formatters.tags(config, event));
 
     // Field set
-    const values = internals.serialize(getEventValues(event));
-
-    const values = Formatters.serialize(eventValues);
+    const values = Formatters.serialize(getEventValues(event));
 
     let loadValues = [];
     if (eventName === 'ops') {

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -1,77 +1,39 @@
 'use strict';
 
 /**
+ * TODO: Is this docs link up to date?  Check.
  * Converts event data to InfluxDB line protocol
  * https://docs.influxdata.com/influxdb/v0.12/write_protocols/line/
  */
 
 // Load modules
-
-const Os = require('os');
-const Qs = require('querystring');
+const Querystring = require('querystring');
 const Url = require('url');
 const Hoek = require('hoek');
-const Stringify = require('fast-safe-stringify');
+const OpsFormatter = require('./ops-format');
 
-// Declare internals
+const Formatters = require('./formatters');
 
-const internals = {
-    host: Os.hostname()
-};
-
-/* eslint-disable no-confusing-arrow */
-internals.Int = (value) => Number.isInteger(Number(value)) ? `${value}i` : value;
-
-internals.String = (value) => {
-    let string;
-
-    if (Object.prototype.toString.call(value) === '[object Object]' &&
-        !Array.isArray(value)) {
-        string = Stringify(value).replace(/"/g, '\\"');
-    }
-    else {
-        string = String(value);
-    }
-
-    return `"${string}"`;
-};
-
-internals.tags = (config, event) => {
-
-    const tags = {
-        host: event.host || internals.host,
-        pid: event.pid
-    };
-
-    if (config.metadata) {
-        Object.keys(config.metadata).forEach((key) => {
-            if (config.metadata[key] !== undefined && config.metadata[key] !== null) {
-                tags[key] = internals.String(config.metadata[key]);
-            }
-        });
-    }
-
-    return tags;
-};
+const internals = {};
 
 internals.formatError = (error) => {
 
     if (!error instanceof Error) {
-        return internals.String(error);
+        return Formatters.String(error);
     }
 
     const result = {
-        'error.name': internals.String(error.name),
-        'error.message': internals.String(error.message),
-        'error.stack': internals.String(error.stack)
+        'error.name': Formatters.String(error.name),
+        'error.message': Formatters.String(error.message),
+        'error.stack': Formatters.String(error.stack)
     };
 
     if (error.isBoom) {
-        result['error.statusCode'] = internals.Int(error.output.statusCode);
+        result['error.statusCode'] = Formatters.Int(error.output.statusCode);
 
         Object.keys(error.data).forEach((key) => {
 
-            result[`error.data.${key}`] = internals.String(error.data[key]);
+            result[`error.data.${key}`] = Formatters.String(error.data[key]);
         });
     }
 
@@ -83,10 +45,10 @@ internals.values = {
         {},
         internals.formatError(event.error),
         {
-            id: internals.String(event.id),
-            url: internals.String(event.url && Url.format(event.url)),
-            method: internals.String(event.method && event.method.toUpperCase()),
-            tags: internals.String(event.tags)
+            id: Formatters.String(event.id),
+            url: Formatters.String(event.url && Url.format(event.url)),
+            method: Formatters.String(event.method && event.method.toUpperCase()),
+            tags: Formatters.String(event.tags)
         }
     ),
     log: (event) => {
@@ -96,13 +58,13 @@ internals.values = {
             return Object.assign(
                 {},
                 internals.formatError(event.data),
-                { tags: internals.String(event.tags) }
+                { tags: Formatters.String(event.tags) }
             );
         }
 
         return {
-            data: internals.String(event.data),
-            tags: internals.String(event.tags)
+            data: Formatters.String(event.data),
+            tags: Formatters.String(event.tags)
         };
     },
     ops: (event) => {
@@ -113,13 +75,13 @@ internals.values = {
             'os.cpu1m': load[0],
             'os.cpu5m': load[1],
             'os.cpu15m': load[2],
-            'os.freemem': internals.Int(Hoek.reach(event, 'os.mem.free')),
-            'os.totalmem': internals.Int(Hoek.reach(event, 'os.mem.total')),
-            'os.uptime': internals.Int(Hoek.reach(event, 'os.uptime')),
+            'os.freemem': Formatters.Int(Hoek.reach(event, 'os.mem.free')),
+            'os.totalmem': Formatters.Int(Hoek.reach(event, 'os.mem.total')),
+            'os.uptime': Formatters.Int(Hoek.reach(event, 'os.uptime')),
             'proc.delay': Hoek.reach(event, 'proc.delay'),
-            'proc.heapTotal': internals.Int(Hoek.reach(event, 'proc.mem.heapTotal')),
-            'proc.heapUsed': internals.Int(Hoek.reach(event, 'proc.mem.heapUsed')),
-            'proc.rss': internals.Int(Hoek.reach(event, 'proc.mem.rss')),
+            'proc.heapTotal': Formatters.Int(Hoek.reach(event, 'proc.mem.heapTotal')),
+            'proc.heapUsed': Formatters.Int(Hoek.reach(event, 'proc.mem.heapUsed')),
+            'proc.rss': Formatters.Int(Hoek.reach(event, 'proc.mem.rss')),
             'proc.uptime': Hoek.reach(event, 'proc.uptime')
         };
     },
@@ -131,44 +93,40 @@ internals.values = {
                 {},
                 internals.formatError(event.data),
                 {
-                    id: internals.String(event.id),
-                    method: internals.String(event.method && event.method.toUpperCase()),
-                    path: internals.String(event.path),
-                    tags: internals.String(event.tags)
+                    id: Formatters.String(event.id),
+                    method: Formatters.String(event.method && event.method.toUpperCase()),
+                    path: Formatters.String(event.path),
+                    tags: Formatters.String(event.tags)
                 }
             );
         }
 
         return {
-            data: internals.String(event.data),
-            id: internals.String(event.id),
-            method: internals.String(event.method && event.method.toUpperCase()),
-            path: internals.String(event.path),
-            tags: internals.String(event.tags)
+            data: Formatters.String(event.data),
+            id: Formatters.String(event.id),
+            method: Formatters.String(event.method && event.method.toUpperCase()),
+            path: Formatters.String(event.path),
+            tags: Formatters.String(event.tags)
         };
     },
     response: (event) => {
 
         return {
-            httpVersion: internals.String(event.httpVersion),
-            id: internals.String(event.id),
-            instance: internals.String(event.instance),
-            labels: internals.String(event.labels),
-            method: internals.String(event.method && event.method.toUpperCase()),
-            path: internals.String(event.path),
-            query: internals.String(Qs.stringify(event.query)),
-            referer: internals.String(Hoek.reach(event, 'source.referer')),
-            remoteAddress: internals.String(Hoek.reach(event, 'source.remoteAddress')),
-            responseTime: internals.Int(event.responseTime),
-            statusCode: internals.Int(event.statusCode),
-            userAgent: internals.String(Hoek.reach(event, 'source.userAgent'))
+            httpVersion: Formatters.String(event.httpVersion),
+            id: Formatters.String(event.id),
+            instance: Formatters.String(event.instance),
+            labels: Formatters.String(event.labels),
+            method: Formatters.String(event.method && event.method.toUpperCase()),
+            path: Formatters.String(event.path),
+            query: Formatters.String(Qs.stringify(event.query)),
+            referer: Formatters.String(Hoek.reach(event, 'source.referer')),
+            remoteAddress: Formatters.String(Hoek.reach(event, 'source.remoteAddress')),
+            responseTime: Formatters.Int(event.responseTime),
+            statusCode: Formatters.Int(event.statusCode),
+            userAgent: Formatters.String(Hoek.reach(event, 'source.userAgent'))
         };
     }
 };
-
-internals.serialize = (obj) => Object.keys(obj)
-    .map((key) => `${key}=${obj[key]}`)
-    .join(',');
 
 module.exports.format = (event, config) => {
     const eventName = event.event;
@@ -185,6 +143,16 @@ module.exports.format = (event, config) => {
     // Field set
     const values = internals.serialize(getEventValues(event));
 
+    const values = Formatters.serialize(eventValues);
+
+    let loadValues = [];
+    if (eventName === 'ops') {
+        loadValues = OpsFormatter.format(event,config);
+    }
+    const eventValue = `${eventName},${tags} ${values} ${timestamp}000000`;
     // Timestamp in InfluxDB is in nanoseconds
-    return `${eventName},${tags} ${values} ${timestamp}000000`;
+    if (loadValues.length === 0) {
+        return eventValue;
+    }
+    return [eventValue].concat(loadValues).join('\n');
 };

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -17,10 +17,6 @@ const internals = {};
 
 internals.formatError = (error) => {
 
-    if (!error instanceof Error) {
-        return Formatters.String(error);
-    }
-
     const result = {
         'error.name': Formatters.String(error.name),
         'error.message': Formatters.String(error.message),
@@ -117,7 +113,7 @@ internals.values = {
             labels: Formatters.String(event.labels),
             method: Formatters.String(event.method && event.method.toUpperCase()),
             path: Formatters.String(event.path),
-            query: Formatters.String(Qs.stringify(event.query)),
+            query: Formatters.String(Querystring.stringify(event.query)),
             referer: Formatters.String(Hoek.reach(event, 'source.referer')),
             remoteAddress: Formatters.String(Hoek.reach(event, 'source.remoteAddress')),
             responseTime: Formatters.Int(event.responseTime),

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -1,9 +1,8 @@
 'use strict';
 
 /**
- * TODO: Is this docs link up to date?  Check.
  * Converts event data to InfluxDB line protocol
- * https://docs.influxdata.com/influxdb/v0.12/write_protocols/line/
+ * https://docs.influxdata.com/influxdb/v1.2/write_protocols/line_protocol_tutorial/
  */
 
 // Load modules

--- a/lib/ops-format.js
+++ b/lib/ops-format.js
@@ -103,7 +103,7 @@ const opsFormatHelper = (eventName, timestamp, tags, eventValues, config) => {
 
 module.exports.format = (event, config) => {
     const timestamp = event.timestamp;
-    const tags = Formatters.serialize(Formatters.tags(event));
+    const tags = Formatters.serialize(Formatters.tags(config, event));
 
     let loadValues = [];
     const requests = opsRequests(event);

--- a/lib/ops-format.js
+++ b/lib/ops-format.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const Hoek = require('hoek');
+const Formatters = require('./formatters');
+
+const opsRequests = (event) => {
+    const requests = Hoek.reach(event, 'load.requests');
+    if (Object.keys(requests).length === 0) {
+        return null;
+    }
+    return Object.keys(requests).map((port) => {
+        const statusCodesValues = {};
+        Object.keys(requests[port].statusCodes).forEach((code) => {
+            const key = 'requests' + code;
+            statusCodesValues[key] = requests[port].statusCodes[code];
+        });
+        const fields = Object.assign({
+            requestsTotal: requests[port].total,
+            requestsDisconnects: requests[port].disconnects
+        },statusCodesValues);
+
+        return {
+            tags: { port },
+            fields
+        };
+    });
+};
+
+const opsConcurrents = (event) => {
+    const concurrents = Hoek.reach(event, 'load.concurrents');
+    if (Object.keys(concurrents).length === 0) {
+        return null;
+    }
+
+    return Object.keys(concurrents).map((port) => {
+        return {
+            tags: { port },
+            fields: {
+                concurrents: concurrents[port]
+            }
+        };
+    });
+};
+
+const opsResponseTimes = (event) => {
+    const responseTimes = Hoek.reach(event, 'load.responseTimes');
+    if (Object.keys(responseTimes).length === 0) {
+        return null;
+    }
+    return Object.keys(responseTimes).map((port) => {
+        const stats = {};
+        Object.keys(responseTimes[port]).forEach((aggregator) => {
+            stats[aggregator] = isNaN(responseTimes[port][aggregator]) || (responseTimes[port][aggregator] === null) ? 0 : responseTimes[port][aggregator];
+        });
+        return {
+            tags: { port },
+            fields: stats
+        };
+    });
+};
+
+const opsSockets = (event) => {
+    const sockets = Hoek.reach(event, 'load.sockets');
+    if (Object.keys(sockets).length === 0) {
+        return null;
+    }
+    const socketsValues = {
+        tags: {},
+        fields: {}
+    };
+    Object.keys(sockets).forEach((protocol) => {
+        const key = protocol + 'Total';
+        socketsValues.fields[key] = sockets[protocol].total;
+    });
+    return [socketsValues];
+};
+
+const opsFormatHelper = (eventName, timestamp, tags, eventValues, config) => {
+    if (eventValues !== null) {
+        const finalEventValues = eventValues.map((value) => {
+            if (config.metadata) {
+                Object.keys(config.metadata).forEach( (key) => {
+                    value.fields[key] = Formatters.String(config.metadata[key]);
+                });
+            }
+
+            let finalTags = '';
+            const fields = Formatters.serialize(value.fields);
+            if (value.tags && Object.keys(value.tags).length > 0) {
+                const eventTags = Formatters.serialize(value.tags);
+                finalTags = [tags,eventTags].join(',');
+            }
+            else {
+                finalTags = tags;
+            }
+            // Timestamp in InfluxDB is in nanoseconds
+            return `${eventName},${finalTags} ${fields} ${timestamp}000000`;
+        });
+        return finalEventValues;
+    }
+    return [];
+};
+
+module.exports.format = (event, config) => {
+    const timestamp = event.timestamp;
+    const tags = Formatters.serialize(Formatters.tags(event));
+
+    let loadValues = [];
+    const requests = opsRequests(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_requests',timestamp,tags,requests,config));
+
+    const concurrents = opsConcurrents(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_concurrents',timestamp,tags,concurrents,config));
+
+    const responseTimes = opsResponseTimes(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_responseTimes',timestamp,tags,responseTimes,config));
+
+    const sockets = opsSockets(event);
+    loadValues = loadValues.concat(opsFormatHelper('ops_sockets',timestamp,tags,sockets,config));
+    return loadValues;
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",
   "scripts": {
-    "test": "lab -m 5000 -t 79 -v -La code",
+    "test": "lab -m 5000 -t 92 -v -La code",
     "test-cov-html": "lab -m 5000 -r html -o coverage.html -La code"
   },
   "author": "Frederic Hemberger (https://frederic-hemberger.de/)",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,20 +39,65 @@ const testEvent = {
         delay: 0.07090700045228004
     },
     load: {
-        requests: {},
-        concurrents: { '8080': 0 },
-        responseTimes: {}
+        requests: {
+            8080: {
+                total: 9,
+                disconnects: 0,
+                statusCodes: {
+                    200: 9
+                }
+            }
+        },
+        concurrents: { 8080: 1 },
+        responseTimes: {
+            8080: {
+                avg: 999,
+                max: 2222
+            }
+        },
+        sockets: {
+            http: {
+                total: 0
+            },
+            https: {
+                total: 2
+            }
+        }
     }
 };
+
 /* eslint max-len: ["error", 440, 4] */
 const expectedMessage = 'ops,host=mytesthost,pid=9876,testing="superClutch",version="0",name="" os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192 123456789000000';
 const msgWithoutMetadata = 'ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192 123456789000000';
 
+/**
+ * TODO: Find some way to make sure this has actually been hit
+ *
+ * Checking that the events sent to InfluxDB:
+ *  1) Starts with "ops"
+ *  2) Contains the custom metadata specified
+ *
+ * Not very comprehensive validation of the events in this test since more comprehensive
+ * testing is done in line-protocol.test.js.
+ *
+ * @param [String] responseData
+ */
+const validateResponses = (responseData, expectedEvents) => {
+    const expectedLength = expectedEvents || 25;
+    const dataRows = responseData.split('\n');
+    // Because threshold is 5, expect 5 events to be sent at a time
+    // Since 5 influx events are emitted per ops event, expect length to equal 25
+    expect(dataRows.length).to.equal(expectedLength);
+    dataRows.forEach((datum) => {
+        expect(datum).to.match(/^ops/);
+        expect(datum).to.match(/testing="superClutch"/);
+    });
+};
+
 const mocks = {
     readStream() {
         const result = new Stream.Readable({ objectMode: true });
-        // Need to overwrite this function. For some reason all it does is Error('not implemented')  Very helpful, no?
-        /* eslint-disable no-empty-function */
+        // Need to overwrite this function. For some reason all it does is Error('not implemented').
         result._read = () => { };
         return result;
     },
@@ -72,13 +117,7 @@ const mocks = {
             });
             req.on('end', () => {
                 hitCount += 1;
-                const dataRows = data.split('\n');
-
-                // Because threshold is 5, expect 5 events to be sent at a time
-                expect(dataRows.length).to.equal(5);
-                dataRows.forEach((datum) => {
-                    expect(datum).to.equal(expectedMsg);
-                });
+                validateResponses(data);
 
                 res.end();
                 if (hitCount >= 2) {
@@ -90,18 +129,13 @@ const mocks = {
         return server;
     },
 
-    getUdpServer(done) {
+    getUdpServer(expectedNumberOfEvents, done) {
         let hitCount = 0;
         const server = Dgram.createSocket('udp4');
         server.on('message', (msg) => {
             hitCount += 1;
-            const splitMessage = msg.toString().split('\n');
+            validateResponses(msg.toString(), expectedNumberOfEvents);
 
-            // Because threshold is 5, expect 5 events to be sent at a time
-            expect(splitMessage.length).to.equal(5);
-            splitMessage.forEach((msgRow) => {
-                expect(msgRow).to.equal(expectedMessage);
-            });
             if (hitCount >= 2) {
                 server.close(done);
             }
@@ -121,37 +155,80 @@ const Options = {
 };
 
 describe('GoodInflux', () => {
-    it('Http URL => Sends events in a stream to HTTP server', (done) => {
-        const server = mocks.getHttpServer(expectedMessage, done);
-        const stream = mocks.readStream();
+    describe('Http URL =>', () => {
+        it('Sends events in a stream to HTTP server', (done) => {
+            const server = mocks.getHttpServer(done);
+            const stream = mocks.readStream();
 
-        server.listen(0, '127.0.0.1', () => {
-            const reporter = new GoodInflux(mocks.getUri(server, 'http'), Options);
+            server.listen(0, '127.0.0.1', () => {
+                const reporter = new GoodInflux(mocks.getUri(server, 'http'), Options);
+                stream.pipe(reporter);
 
-            stream.pipe(reporter);
-
-            // Important to send 10 events. Threshold is 5, so two batches of events are sent.
-            // Sending two batches proves that the callback is being passed properly to Wreck.request.
-            for (let i = 0; i < 10; i += 1) {
-                stream.push(testEvent);
-            }
+                // Important to send 10 events. Threshold is 5, so two batches of events are sent.
+                // Sending two batches proves that the callback is being passed properly to Wreck.request.
+                for (let i = 0; i < 10; i += 1) {
+                    stream.push(testEvent);
+                }
+            });
         });
     });
 
-    it('Udp URL => Sends events in a stream to UDP server', (done) => {
-        const server = mocks.getUdpServer(done);
-        const stream = mocks.readStream();
+    describe('Udp URL =>', () => {
+        it('Threshold not set => Sends 25 events in a stream to UDP server', (done) => {
+            const server = mocks.getUdpServer(25, done);
+            const stream = mocks.readStream();
 
-        server.on('listening', () => {
-            const reporter = new GoodInflux(mocks.getUri(server, 'udp'), Options);
+            server.on('listening', () => {
+                const reporter = new GoodInflux(mocks.getUri(server, 'udp'), Options);
 
-            stream.pipe(reporter);
+                stream.pipe(reporter);
 
-            // Important to send 10 events. Threshold is 5, so two batches of events are sent.
-            // Sending two batches proves that the callback is being passed properly to this._udpClient.send.
-            for (let i = 0; i < 10; i += 1) {
-                stream.push(testEvent);
-            }
+                // Important to send 10 events. Threshold is 5, so two batches of events are sent.
+                // Sending two batches proves that the callback is being passed properly to this._udpClient.send.
+                for (let i = 0; i < 10; i += 1) {
+                    stream.push(testEvent);
+                }
+            });
+        });
+
+        it('Threshold of 3 => Sends 15 events in a stream to UDP server', (done) => {
+            const server = mocks.getUdpServer(15, done);
+            const stream = mocks.readStream();
+
+            server.on('listening', () => {
+                const reporter = new GoodInflux(mocks.getUri(server, 'udp'), {
+                    threshold: 3,
+                    metadata: { testing: 'superClutch' }
+                });
+
+                stream.pipe(reporter);
+
+                // Important to send 6 events. Threshold is 3, so two batches of events are sent.
+                // Sending two batches proves that the callback is being passed properly to this._udpClient.send.
+                for (let i = 0; i < 6; i += 1) {
+                    stream.push(testEvent);
+                }
+            });
+        });
+
+        it('Threshold of 13 => Sends 25 events in a stream to UDP server', (done) => {
+            const server = mocks.getUdpServer(25, done);
+            const stream = mocks.readStream();
+
+            server.on('listening', () => {
+                const reporter = new GoodInflux(mocks.getUri(server, 'udp'), {
+                    threshold: 13,
+                    metadata: { testing: 'superClutch' }
+                });
+
+                stream.pipe(reporter);
+
+                // Important to send 10 events. Threshold is 5, so two batches of events are sent.
+                // Sending two batches proves that the callback is being passed properly to this._udpClient.send.
+                for (let i = 0; i < 10; i += 1) {
+                    stream.push(testEvent);
+                }
+            });
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,80 +17,31 @@ const it = lab.it;
 const expect = Code.expect;
 
 const testEvent = {
-    event: 'ops',
-    timestamp: 123456789,
+    event: 'log',
     host: 'mytesthost',
-    pid: 9876,
-    os: {
-        load: [1.8408203125, 1.44287109375, 1.15234375],
-        mem: {
-            total: 6089818112,
-            free: 162570240
-        },
-        uptime: 11546
-    },
-    proc: {
-        uptime: 18.192,
-        mem: {
-            rss: 55812096,
-            heapTotal: 41546080,
-            heapUsed: 27708712
-        },
-        delay: 0.07090700045228004
-    },
-    load: {
-        requests: {
-            8080: {
-                total: 9,
-                disconnects: 0,
-                statusCodes: {
-                    200: 9
-                }
-            }
-        },
-        concurrents: { 8080: 1 },
-        responseTimes: {
-            8080: {
-                avg: 999,
-                max: 2222
-            }
-        },
-        sockets: {
-            http: {
-                total: 0
-            },
-            https: {
-                total: 2
-            }
-        }
-    }
+    timestamp: 1485996802647,
+    tags: ['info', 'request'],
+    data: 'Things are good',
+    pid: 1234
 };
 
-/* eslint max-len: ["error", 440, 4] */
-// const msgWithMetadata = 'ops,host=mytesthost,pid=9876,testing="superClutch",version="0",name="" os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192 123456789000000';
-const tagsWithMetadata = /host=mytesthost,pid=9876,testing="superClutch",version="0",name="" /
-// const tagsWithoutMetadata = 'ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192 123456789000000';
-const tagsWithoutMetadata = /host=mytesthost,pid=9876 /
+const msgWithMetadata = 'log,host=mytesthost,pid=1234,testing="superClutch",version="0",name="" data="Things are good",tags="info,request" 1485996802647000000';
+const msgWithoutMetadata = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
 
 /**
- * Checking that the events sent to InfluxDB:
- *  1) Starts with "ops"
- *  2) Contains the custom metadata specified
- *
- * Not very comprehensive validation of the events in this test since more comprehensive
- * testing is done in line-protocol.test.js.
+ * Checking that the events sent to InfluxDB are formatted properly.
+ * Also checking that correct number of events are sent.
  *
  * @param [String] responseData
  * @param [Number] expectedEvents
  */
-const validateResponses = (responseData, expectedEvents, metadataRegex) => {
+const validateResponses = (responseData, expectedEvents, expectedMessage) => {
     const expectedLength = expectedEvents || 25;
     const dataRows = responseData.split('\n');
 
     expect(dataRows.length).to.equal(expectedLength);
     dataRows.forEach((datum) => {
-        expect(datum).to.match(/^ops/)
-        expect(datum).to.match(metadataRegex);
+        expect(datum).to.equal(expectedMessage);
     });
 };
 
@@ -117,7 +68,7 @@ const mocks = {
             });
             req.on('end', () => {
                 hitCount += 1;
-                validateResponses(data, 25, expectedMsg);
+                validateResponses(data, 5, expectedMsg);
 
                 res.end();
                 if (hitCount >= 2) {
@@ -157,7 +108,7 @@ const Options = {
 describe('GoodInflux', () => {
     describe('Http URL =>', () => {
         it('Sends events in a stream to HTTP server', (done) => {
-            const server = mocks.getHttpServer(tagsWithMetadata, done);
+            const server = mocks.getHttpServer(msgWithMetadata, done);
             const stream = mocks.readStream();
 
             server.listen(0, '127.0.0.1', () => {
@@ -174,8 +125,8 @@ describe('GoodInflux', () => {
     });
 
     describe('Udp URL =>', () => {
-        it('Threshold not set => Sends 25 events in a stream to UDP server', (done) => {
-            const server = mocks.getUdpServer(25, tagsWithMetadata, done);
+        it('Threshold not set => Sends 5 events in a stream to UDP server', (done) => {
+            const server = mocks.getUdpServer(5, msgWithMetadata, done);
             const stream = mocks.readStream();
 
             server.on('listening', () => {
@@ -191,14 +142,13 @@ describe('GoodInflux', () => {
             });
         });
 
-        it('Threshold of 3 => Sends 15 events in a stream to UDP server', (done) => {
-            const server = mocks.getUdpServer(15, tagsWithMetadata, done);
+        it('Threshold of 3 => Sends 3 events in a stream to UDP server', (done) => {
+            const server = mocks.getUdpServer(3, msgWithoutMetadata, done);
             const stream = mocks.readStream();
 
             server.on('listening', () => {
                 const reporter = new GoodInflux(mocks.getUri(server, 'udp'), {
-                    threshold: 3,
-                    metadata: { testing: 'superClutch' }
+                    threshold: 3
                 });
 
                 stream.pipe(reporter);
@@ -211,14 +161,13 @@ describe('GoodInflux', () => {
             });
         });
 
-        it('Threshold of 13 => Sends 25 events in a stream to UDP server', (done) => {
-            const server = mocks.getUdpServer(25, tagsWithMetadata, done);
+        it('Threshold of 13 => Sends 5 events in a stream to UDP server', (done) => {
+            const server = mocks.getUdpServer(5, msgWithoutMetadata, done);
             const stream = mocks.readStream();
 
             server.on('listening', () => {
                 const reporter = new GoodInflux(mocks.getUri(server, 'udp'), {
-                    threshold: 13,
-                    metadata: { testing: 'superClutch' }
+                    threshold: 13
                 });
 
                 stream.pipe(reporter);
@@ -240,7 +189,7 @@ describe('GoodInflux', () => {
     });
 
     it('Omit metadata when not defined', (done) => {
-        const server = mocks.getHttpServer(tagsWithoutMetadata, done);
+        const server = mocks.getHttpServer(msgWithoutMetadata, done);
         const stream = mocks.readStream();
 
         server.listen(0, '127.0.0.1', () => {
@@ -259,7 +208,7 @@ describe('GoodInflux', () => {
     });
 
     it('Omit metadata when empty', (done) => {
-        const server = mocks.getHttpServer(tagsWithoutMetadata, done);
+        const server = mocks.getHttpServer(msgWithoutMetadata, done);
         const stream = mocks.readStream();
 
         server.listen(0, '127.0.0.1', () => {
@@ -279,7 +228,7 @@ describe('GoodInflux', () => {
     });
 
     it('Omit undefined metadata', (done) => {
-        const server = mocks.getHttpServer(tagsWithMetadata, done);
+        const server = mocks.getHttpServer(msgWithMetadata, done);
         const stream = mocks.readStream();
 
         const opts = Hoek.clone(Options);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -71,8 +71,6 @@ const expectedMessage = 'ops,host=mytesthost,pid=9876,testing="superClutch",vers
 const msgWithoutMetadata = 'ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,os.cpu5m=1.44287109375,os.cpu15m=1.15234375,os.freemem=162570240i,os.totalmem=6089818112i,os.uptime=11546i,proc.delay=0.07090700045228004,proc.heapTotal=41546080i,proc.heapUsed=27708712i,proc.rss=55812096i,proc.uptime=18.192 123456789000000';
 
 /**
- * TODO: Find some way to make sure this has actually been hit
- *
  * Checking that the events sent to InfluxDB:
  *  1) Starts with "ops"
  *  2) Contains the custom metadata specified
@@ -81,12 +79,12 @@ const msgWithoutMetadata = 'ops,host=mytesthost,pid=9876 os.cpu1m=1.8408203125,o
  * testing is done in line-protocol.test.js.
  *
  * @param [String] responseData
+ * @param [Number] expectedEvents
  */
 const validateResponses = (responseData, expectedEvents) => {
     const expectedLength = expectedEvents || 25;
     const dataRows = responseData.split('\n');
-    // Because threshold is 5, expect 5 events to be sent at a time
-    // Since 5 influx events are emitted per ops event, expect length to equal 25
+
     expect(dataRows.length).to.equal(expectedLength);
     dataRows.forEach((datum) => {
         expect(datum).to.match(/^ops/);

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -10,58 +10,6 @@ const describe = lab.describe;
 const it = lab.it;
 const expect = Code.expect;
 
-const testHost = 'myservice.awesome.com';
-
-const getExpectedMessage = (ports, metadata) => {
-    const plusMetadata = metadata || '';
-    /* eslint max-len: ["error", 440, 4] */
-    const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
-    const eventHost = 'host=myservice.awesome.com,pid=128';
-    const loadOpsEvents = ports.map((port) => {
-        return [
-            `ops_requests,${eventHost} port=${port},requestsTotal=1,requestsDisconnects=1,requests200=61`,
-            `ops_concurrents,${eventHost} port=${port},concurrents=23`,
-            `ops_responseTimes,${eventHost} port=${port},avg=990,max=1234`,
-            `ops_sockets,${eventHost} port=${port},httpTotal=19,httpsTotal=49`
-        ].join('\n');
-    });
-    return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');
-};
-
-const testOpsEventBase = JSON.stringify({
-    event: 'ops',
-    timestamp: 1485996802647,
-    host: testHost,
-    pid: 9876,
-    os: {
-        load: [3.05078125, 2.11279296875, 1.625],
-        mem: { total: 6089818112, free: 147881984 },
-        uptime: 23489
-    },
-    proc: {
-        uptime: 22.878,
-        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
-        delay: 32.29
-    },
-    load: {
-        requests: { '8080':
-            { total: 94, disconnects: 1, statusCodes: { '200': 61 } }
-        },
-        concurrents: { '8080': 23 },
-        responseTimes: { '8080': { avg: 990, max: 1234 } },
-        sockets: { http: { total: 19 }, https: { total: 49 } }
-    }
-});
-
-describe('ops', () => {
-    it('One port => two events created', (done) => {
-        const testEvent = JSON.parse(testOpsEventBase);
-        const formattedEvent = LineProtocol.format(testEvent, {});
-        expect(formattedEvent).to.equal(getExpectedMessage(['8080']));
-        done();
-    });
-});
-
 describe('log', () => {
     it('Event log is formatted as expected', (done) => {
         const testEvent = {
@@ -146,7 +94,7 @@ describe('error', () => {
             url    : '/hello',
             method : 'GET',
             tags   : ['error','crash'],
-            pid: 1234
+            pid    : 1234
         };
         const formattedLogEvent = LineProtocol.format(testEvent, {});
         const expectedLogEvent = 'error,host=mytesthost,pid=1234 error.name="error1",error.message="this is an error msg",error.stack="stackoverflow",id="1234",url="/hello",method="GET",tags="error,crash" 1485996802647000000';

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -102,3 +102,15 @@ describe('error', () => {
         done();
     });
 });
+
+describe('Unrecognized event', () => {
+    it('LineProtocol simply returns', (done) => {
+        const testEvent = {
+            event: 'hello',
+            host: 'mytesthost',
+            timestamp: 1485996802647
+        };
+        expect(LineProtocol.format(testEvent, {})).to.equal(undefined);
+        done();
+    });
+});

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const LineProtocol = require('../lib/line-protocol');
+
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+const testHost = 'myservice.awesome.com';
+
+const getExpectedMessage = (ports, metadata) => {
+    const plusMetadata = metadata || '';
+    /* eslint max-len: ["error", 440, 4] */
+    const expectedBaseMessage = `ops,host=${testHost},pid=9876 os.cpu1m=3.05078125,os.cpu5m=2.11279296875,os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,proc.heapUsed=26825384i,proc.rss=64290816i,proc.uptime=22.878${plusMetadata} 1485996802647000000`;
+    const eventHost = 'host=myservice.awesome.com,pid=128';
+    const loadOpsEvents = ports.map((port) => {
+        return [
+            `ops_requests,${eventHost} port=${port},requestsTotal=1,requestsDisconnects=1,requests200=61`,
+            `ops_concurrents,${eventHost} port=${port},concurrents=23`,
+            `ops_responseTimes,${eventHost} port=${port},avg=990,max=1234`,
+            `ops_sockets,${eventHost} port=${port},httpTotal=19,httpsTotal=49`
+        ].join('\n');
+    });
+    return expectedBaseMessage + '\n' + loadOpsEvents.join('\n');
+};
+
+const testOpsEventBase = JSON.stringify({
+    event: 'ops',
+    timestamp: 1485996802647,
+    host: testHost,
+    pid: 9876,
+    os: {
+        load: [3.05078125, 2.11279296875, 1.625],
+        mem: { total: 6089818112, free: 147881984 },
+        uptime: 23489
+    },
+    proc: {
+        uptime: 22.878,
+        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
+        delay: 32.29
+    },
+    load: {
+        requests: { '8080':
+            { total: 94, disconnects: 1, statusCodes: { '200': 61 } }
+        },
+        concurrents: { '8080': 23 },
+        responseTimes: { '8080': { avg: 990, max: 1234 } },
+        sockets: { http: { total: 19 }, https: { total: 49 } }
+    }
+});
+
+describe('ops', () => {
+    it('One port => two events created', (done) => {
+        const testEvent = JSON.parse(testOpsEventBase);
+        const formattedEvent = LineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(getExpectedMessage(['8080']));
+        done();
+    });
+});
+
+describe('log', () => {
+    it('Event log is formatted as expected', (done) => {
+        const testEvent = {
+            event: 'log',
+            host: 'mytesthost',
+            timestamp: 1485996802647,
+            tags: ['info', 'request'],
+            data: 'Things are good',
+            pid: 1234
+        };
+        const formattedLogEvent = LineProtocol.format(testEvent, {});
+        const expectedLogEvent = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
+        expect(formattedLogEvent).to.equal(expectedLogEvent);
+        done();
+    });
+});
+
+describe('request', () => {
+    it('Event request is formatted as expected', (done) => {
+        const testEvent = {
+            event: 'request',
+            host: 'mytesthost',
+            timestamp: 1485996802647,
+            data: 'userid=001',
+            id: '4321',
+            path: '/hello',
+            method: 'POST',
+            tags: ['request','blahblahblah'],
+            pid: 1234
+        };
+        const formattedLogEvent = LineProtocol.format(testEvent, {});
+        const expectedLogEvent = 'request,host=mytesthost,pid=1234 data="userid=001",id="4321",method="POST",path="/hello",tags="request,blahblahblah" 1485996802647000000';
+        expect(formattedLogEvent).to.equal(expectedLogEvent);
+        done();
+    });
+});
+
+
+describe('response', () => {
+    it('Event response is formatted as expected', (done) => {
+        const testEvent = {
+            event: 'response',
+            host: 'mytesthost',
+            timestamp: 1485996802647,
+            httpVersion   : '1.1',
+            id            : '1234',
+            instance      : 'mytesthost',
+            labels        : 'label001',
+            method        : 'GET',
+            path          : '/hello',
+            source : {
+                referer       : 'referer',
+                remoteAddress : '127.0.0.1',
+                userAgent     : 'Chrome'
+            },
+            query : {
+                k1: 'v1', k2: 'v2'
+            },
+            responseTime  : 500,
+            statusCode    : 200,
+            pid           : 1234
+        };
+        const formattedLogEvent = LineProtocol.format(testEvent, {});
+        const expectedLogEvent = 'response,host=mytesthost,pid=1234 httpVersion="1.1",id="1234",instance="mytesthost",labels="label001",method="GET",path="/hello",query="k1=v1&k2=v2",referer="referer",remoteAddress="127.0.0.1",responseTime=500i,statusCode=200i,userAgent="Chrome" 1485996802647000000';
+        expect(formattedLogEvent).to.equal(expectedLogEvent);
+        done();
+    });
+});
+
+describe('error', () => {
+    it('Event error is formatted as expected', (done) => {
+        const testEvent = {
+            event: 'error',
+            host: 'mytesthost',
+            timestamp: 1485996802647,
+            error : {
+                name   : 'error1',
+                message : 'this is an error msg',
+                stack  : 'stackoverflow'
+            },
+            id     : '1234',
+            url    : '/hello',
+            method : 'GET',
+            tags   : ['error','crash'],
+            pid: 1234
+        };
+        const formattedLogEvent = LineProtocol.format(testEvent, {});
+        const expectedLogEvent = 'error,host=mytesthost,pid=1234 error.name="error1",error.message="this is an error msg",error.stack="stackoverflow",id="1234",url="/hello",method="GET",tags="error,crash" 1485996802647000000';
+        expect(formattedLogEvent).to.equal(expectedLogEvent);
+        done();
+    });
+});

--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -61,7 +61,6 @@ const getExpectedMessage = (ports, metadata, responseTimesAvg, responseTimesMax)
     });
     const loadOpsSocketsEvents = [`ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`];
 
-    // TODO: Flatten array instead.
     const finalOpsEvents = [
         loadOpsRequestsEvents,
         loadOpsConcurrentsEvents,

--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -100,8 +100,6 @@ describe('ops all events', () => {
 });
 
 describe('ops_responseTimes avg max', () => {
-    // TODO: This was an important design decision.  If avg and max are not numbers
-    // then should their values be 0?  What does the team think?
     it('avg is null and max is string => avg and max shall be 0s', (done) => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.responseTimes['8080'].avg = null;

--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const LineProtocol = require('../lib/line-protocol');
+
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+const testHost = 'myservice.awesome.com';
+
+const testOpsEventBase = JSON.stringify({
+    event: 'ops',
+    timestamp: 1485996802647,
+    host: testHost,
+    pid: 9876,
+    os: {
+        load: [3.05078125, 2.11279296875, 1.625],
+        mem: { total: 6089818112, free: 147881984 },
+        uptime: 23489
+    },
+    proc: {
+        uptime: 22.878,
+        mem: { rss: 64290816, heapTotal: 47271936, heapUsed: 26825384 },
+        delay: 32.29
+    },
+    load: {
+        requests: { '8080':
+            { total: 94, disconnects: 1, statusCodes: { '200': 61 } }
+        },
+        concurrents: { '8080': 23 },
+        responseTimes: { '8080': { avg: 990, max: 1234 } },
+        sockets: { http: { total: 19 }, https: { total: 49 } }
+    }
+});
+
+const getExpectedMessage = (ports, metadata, responseTimesAvg, responseTimesMax) => {
+    const plusMetadata = metadata || '';
+    const avg = isNaN(responseTimesAvg) ? 990 : responseTimesAvg;
+    const max = isNaN(responseTimesMax) ? 1234 : responseTimesMax;
+    const eventHost = `host=${testHost},pid=9876`;
+    const expectedBaseMessage = [
+        `ops,${eventHost} os.cpu1m=3.05078125,os.cpu5m=2.11279296875,`,
+        'os.cpu15m=1.625,os.freemem=147881984i,os.totalmem=6089818112i,',
+        'os.uptime=23489i,proc.delay=32.29,proc.heapTotal=47271936i,',
+        'proc.heapUsed=26825384i,proc.rss=64290816i,',
+        `proc.uptime=22.878${plusMetadata} 1485996802647000000`
+    ].join('');
+
+    const loadOpsRequestsEvents = ports.map((port) => {
+        return `ops_requests,${eventHost},port=${port} requestsTotal=94,requestsDisconnects=1,requests200=61 1485996802647000000`;
+    });
+    const loadOpsConcurrentsEvents = ports.map((port) => {
+        return `ops_concurrents,${eventHost},port=${port} concurrents=23 1485996802647000000`;
+    });
+    const loadOpsResponseTimesEvents = ports.map((port) => {
+        return `ops_responseTimes,${eventHost},port=${port} avg=${avg},max=${max} 1485996802647000000`;
+    });
+    const loadOpsSocketsEvents = [`ops_sockets,${eventHost} httpTotal=19,httpsTotal=49 1485996802647000000`];
+
+    // TODO: Flatten array instead.
+    const finalOpsEvents = [
+        loadOpsRequestsEvents,
+        loadOpsConcurrentsEvents,
+        loadOpsResponseTimesEvents,
+        loadOpsSocketsEvents
+    ].reduce( (a,b) => a.concat(b));
+
+    return expectedBaseMessage + '\n' + finalOpsEvents.join('\n');
+};
+
+describe('ops all events', () => {
+    it('One port => five events created', (done) => {
+        const testEvent = JSON.parse(testOpsEventBase);
+        const formattedEvent = LineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(getExpectedMessage(['8080']));
+        done();
+    });
+    it('Two ports => nine events created', (done) => {
+        const testEvent = JSON.parse(testOpsEventBase);
+        testEvent.load.requests['8081'] = testEvent.load.requests['8080'];
+        testEvent.load.concurrents['8081'] = testEvent.load.concurrents['8080'];
+        testEvent.load.responseTimes['8081'] = testEvent.load.responseTimes['8080'];
+        const formattedEvent = LineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(getExpectedMessage(['8080','8081']));
+        done();
+    });
+    it('No ports reported => Only format the ops event', (done) => {
+        const testEvent = JSON.parse(testOpsEventBase);
+        testEvent.load.requests = {};
+        testEvent.load.concurrents = {};
+        testEvent.load.responseTimes = {};
+
+        const formattedEvent = LineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(getExpectedMessage([]));
+        done();
+    });
+});
+
+describe('ops_responseTimes avg max', () => {
+    // TODO: This was an important design decision.  If avg and max are not numbers
+    // then should their values be 0?  What does the team think?
+    it('avg is null and max is string => avg and max shall be 0s', (done) => {
+        const testEvent = JSON.parse(testOpsEventBase);
+        testEvent.load.responseTimes['8080'].avg = null;
+        testEvent.load.responseTimes['8080'].max = 'abc';
+        const formattedEvent = LineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(getExpectedMessage(['8080'],null,0,0));
+        done();
+    });
+    it('avg and max are both numbers => avg and max shall be numbers', (done) => {
+        const testEvent = JSON.parse(testOpsEventBase);
+        testEvent.load.responseTimes['8080'].avg = 123;
+        testEvent.load.responseTimes['8080'].max = '456';
+        const formattedEvent = LineProtocol.format(testEvent, {});
+        expect(formattedEvent).to.equal(getExpectedMessage(['8080'],null,123,456));
+        done();
+    });
+});


### PR DESCRIPTION
_#10 became pretty thorny due to merge conflicts, so I decided to just create a new PR.  Description from that PR:_

Previously, some of the data from `ops` events was not being included in the stats sent to InfluxDB.  In this pull request, we have included all `ops` data.

As discussed in #4 , we decided to separate out `ops` data into several events.  In this PR, a single `ops` event from Hapi Good will now emit:
* The same `ops` event as before (so backwards compatibility should not be broken)
* One of each of the following events for each port:
  * `ops_requests`
  * `ops_concurrents`
  * `ops_responseTimes`
* One `ops_sockets` event

We also improved unit test coverage quite a bit, with all formatters having explicit tests.

We have been using this module in production for a number of our services and it seems to be working quite nicely.  I have Grafana graphs that query most of the ops events.  We don't use this module to report other event types just yet, so if there is some way to beta test that out it might be nice.

Special thanks to @wei-hai since he actually did the bulk of the work here -- but didn't want the glory of the pull request.