### PR TITLE
Remove Quotes from Metadata

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -39,9 +39,9 @@ const tags = (config, event) => {
             const value = config.metadata[key];
             if (value !== undefined && value !== null && value !== '') {
                 completeTags[key] = `${value}`
-                    .replace(',', '\,')
-                    .replace('=', '\=')
-                    .replace(' ', '\ ');
+                    .replace(',', '\\,')
+                    .replace('=', '\\=')
+                    .replace(' ', '\\ ');
             }
         });
     }

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -33,7 +33,8 @@ const tags = (config, event) => {
 
     if (config.metadata) {
         Object.keys(config.metadata).forEach((key) => {
-            if (config.metadata[key] !== undefined && config.metadata[key] !== null) {
+            const value = config.metadata[key];
+            if (value !== undefined && value !== null && value !== '') {
                 completeTags[key] = formatString(config.metadata[key]);
             }
         });

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -24,6 +24,9 @@ const formatString = (value) => {
     return `"${string}"`;
 };
 
+// If metadata is configured, add it to the tags.
+// Special characters are escaped as defined in InfluxDB documentation:
+// https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_tutorial/
 const tags = (config, event) => {
 
     const completeTags = {
@@ -35,7 +38,10 @@ const tags = (config, event) => {
         Object.keys(config.metadata).forEach((key) => {
             const value = config.metadata[key];
             if (value !== undefined && value !== null && value !== '') {
-                completeTags[key] = formatString(config.metadata[key]);
+                completeTags[key] = `${value}`
+                    .replace(',', '\,')
+                    .replace('=', '\=')
+                    .replace(' ', '\ ');
             }
         });
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,7 +25,7 @@ const testEvent = {
     pid: 1234
 };
 
-const msgWithMetadata = 'log,host=mytesthost,pid=1234,testing="superClutch",version="0",name="" data="Things are good",tags="info,request" 1485996802647000000';
+const msgWithMetadata = 'log,host=mytesthost,pid=1234,testing=superClutch,version=0 data="Things are good",tags="info,request" 1485996802647000000';
 const msgWithoutMetadata = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
 
 /**
@@ -101,6 +101,7 @@ const Options = {
     metadata: {
         testing: 'superClutch',
         version: 0,
+        // TODO: What to do about empty strings?
         name: ''
     }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,7 +101,6 @@ const Options = {
     metadata: {
         testing: 'superClutch',
         version: 0,
-        // TODO: What to do about empty strings?
         name: ''
     }
 };

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -114,3 +114,59 @@ describe('Unrecognized event', () => {
         done();
     });
 });
+
+describe('Metadata', () => {
+    const testEvent = {
+        event: 'log',
+        host: 'mytesthost',
+        timestamp: 1485996802647,
+        tags: ['info', 'request'],
+        data: 'Things are good',
+        pid: 1234
+    };
+
+    it('No metadata set => Tags contain host and PID', (done) => {
+        const logEventNoMetadata = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
+        expect(LineProtocol.format(testEvent, {})).to.equal(logEventNoMetadata)
+        done()
+    })
+
+    it('Metadata set => Contained in tags', (done) => {
+        const configs = {
+            metadata: {
+                protocol: 'magic'
+            }
+        }
+        const logEventWithMetadata = 'log,host=mytesthost,pid=1234,protocol=magic data="Things are good",tags="info,request" 1485996802647000000';
+        expect(LineProtocol.format(testEvent, configs)).to.equal(logEventWithMetadata)
+    })
+
+    it('Special characters properly escaped', (done) => {
+        const configs = {
+            metadata: {
+                'My,Home': 'BikeCity,USA',
+                'proto=col': 'magic',
+                'bless': 'the rains'
+            }
+        }
+        const tagSet = 'host=mytesthost,pid=1234,My\,Home=BikeCity\,USA,proto\=col=magic, bless=the\ rains'
+
+        const logEventSpecialChars = `log,${tagSet} data="Things are good",tags="info,request" 1485996802647000000`;
+
+        expect(LineProtocol.format(testEvent, configs)).to.equal(logEventSpecialChars)
+    })
+
+    it('Null, undefined and empty string => no metadata added', (done) => {
+        const configs = {
+            metadata: {
+                nullValue: null,
+                undefinedValue: undefined,
+                emptyString: ''
+            }
+        }
+
+        const logEventNoMetadata = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
+        expect(LineProtocol.format(testEvent, configs)).to.equal(logEventNoMetadata)
+        done()
+    })
+})

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -127,34 +127,36 @@ describe('Metadata', () => {
 
     it('No metadata set => Tags contain host and PID', (done) => {
         const logEventNoMetadata = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
-        expect(LineProtocol.format(testEvent, {})).to.equal(logEventNoMetadata)
-        done()
-    })
+        expect(LineProtocol.format(testEvent, {})).to.equal(logEventNoMetadata);
+        done();
+    });
 
     it('Metadata set => Contained in tags', (done) => {
         const configs = {
             metadata: {
                 protocol: 'magic'
             }
-        }
+        };
         const logEventWithMetadata = 'log,host=mytesthost,pid=1234,protocol=magic data="Things are good",tags="info,request" 1485996802647000000';
-        expect(LineProtocol.format(testEvent, configs)).to.equal(logEventWithMetadata)
-    })
+        expect(LineProtocol.format(testEvent, configs)).to.equal(logEventWithMetadata);
+        done();
+    });
 
     it('Special characters properly escaped', (done) => {
         const configs = {
             metadata: {
                 'My,Home': 'BikeCity,USA',
-                'proto=col': 'magic',
+                'proto=col': 'mag=ic',
                 'bless': 'the rains'
             }
-        }
-        const tagSet = 'host=mytesthost,pid=1234,My\,Home=BikeCity\,USA,proto\=col=magic, bless=the\ rains'
+        };
 
+        const tagSet = 'host=mytesthost,pid=1234,My\,Home=BikeCity\,USA,proto\=col=mag\=ic,bless=the\ rains';
         const logEventSpecialChars = `log,${tagSet} data="Things are good",tags="info,request" 1485996802647000000`;
 
-        expect(LineProtocol.format(testEvent, configs)).to.equal(logEventSpecialChars)
-    })
+        expect(LineProtocol.format(testEvent, configs)).to.equal(logEventSpecialChars);
+        done();
+    });
 
     it('Null, undefined and empty string => no metadata added', (done) => {
         const configs = {
@@ -163,10 +165,10 @@ describe('Metadata', () => {
                 undefinedValue: undefined,
                 emptyString: ''
             }
-        }
+        };
 
         const logEventNoMetadata = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
-        expect(LineProtocol.format(testEvent, configs)).to.equal(logEventNoMetadata)
-        done()
-    })
-})
+        expect(LineProtocol.format(testEvent, configs)).to.equal(logEventNoMetadata);
+        done();
+    });
+});

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -145,13 +145,13 @@ describe('Metadata', () => {
     it('Special characters properly escaped', (done) => {
         const configs = {
             metadata: {
-                'My,Home': 'BikeCity,USA',
-                'proto=col': 'mag=ic',
+                'hometown': 'BikeCity,USA',
+                'protocol': 'mag=ic',
                 'bless': 'the rains'
             }
         };
 
-        const tagSet = 'host=mytesthost,pid=1234,My\,Home=BikeCity\,USA,proto\=col=mag\=ic,bless=the\ rains';
+        const tagSet = 'host=mytesthost,pid=1234,hometown=BikeCity\\,USA,protocol=mag\\=ic,bless=the\\ rains';
         const logEventSpecialChars = `log,${tagSet} data="Things are good",tags="info,request" 1485996802647000000`;
 
         expect(LineProtocol.format(testEvent, configs)).to.equal(logEventSpecialChars);


### PR DESCRIPTION
Fixes #18 . As pointed out there, it is improper to add quotes to tag values. Removing them. Also, ensuring special characters are escaped. From InfluxDB's perspective, these are `,`, `=` and ` `.
https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_tutorial/#special-characters-and-keywords

I spun up a test instance of InfluxDB locally and ran this code in a test Hapi server. I was able to write and query data even with funky metadata. I can't remotely say that I _recommend_ such metadata, but suffice to say it did work:

```
> SELECT "path", "serviceName" FROM response WHERE "serviceName" = 'Super Awesome=Service'
name: response
time                     path  serviceName
----                     ----  -----------
2017-09-05T05:57:53.198Z /mind Super Awesome=Service
```