### PR TITLE
Metadata as tags only

### DIFF
--- a/lib/ops-format.js
+++ b/lib/ops-format.js
@@ -78,12 +78,6 @@ const opsSockets = (event) => {
 const opsFormatHelper = (eventName, timestamp, tags, eventValues, config) => {
     if (eventValues !== null) {
         const finalEventValues = eventValues.map((value) => {
-            if (config.metadata) {
-                Object.keys(config.metadata).forEach( (key) => {
-                    value.fields[key] = Formatters.String(config.metadata[key]);
-                });
-            }
-
             let finalTags = '';
             const fields = Formatters.serialize(value.fields);
             if (value.tags && Object.keys(value.tags).length > 0) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",
   "scripts": {
-    "test": "lab -m 5000 -t 92 -v -La code",
+    "test": "lab -m 5000 -t 93 -v -La code",
     "test-cov-html": "lab -m 5000 -r html -o coverage.html -La code"
   },
   "author": "Frederic Hemberger (https://frederic-hemberger.de/)",


### PR DESCRIPTION
Updated ops formatter to only include metadata as tags, not fields. I *believe* this is the expected behavior, since it was originally included as part of #8 

In certain ops metrics, metadata was being included as fields AND tags, rather than just tags. This can confuse older versions of influx, as well as metrics UIs like Grafana, as it requires queries to specify `<name>::field` or `<name>::tag`. 

Removing metadata from fields will slightly reduce the data size, and will also speed up queries by metadata, since influx indexes on tags.

Great project btw, it's saved us lots of time and effort :)