### PR TITLE
Add measurement prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ const options = {
                 metadata: {
                     serviceName: 'SuperAwesomeService',
                     dataCenter: 'Banff'
-                }
+                },
+                prefix: ['my', 'awesome', 'service']
         	}]
         }]
     }
@@ -74,7 +75,9 @@ Creates a new GoodInflux object where:
   - `[errorThreshold]` - number of erroring message sends to tolerate before the plugin fails.  Default is 0.
   - `[wreck]` - configuration object to pass into [`wreck`](https://github.com/hapijs/wreck#advanced). Defaults to `{ timeout: 60000, headers: {} }`. `content-type` is always "text/plain".
   - `[udpType]` - UDP type; defaults to `udp4`. Probably not necessary to change, but more documentation is available on the [NodeJS Dgram Documentation](https://nodejs.org/api/dgram.html#dgram_dgram_createsocket_type_callback)
-  - `[metadata]` - arbitrary information you would like to add to your InfluxDB stats.  This helps you query InfluxDB for the statistics you want.
+  - `[metadata]` - arbitrary tags you would like to add to your InfluxDB stats.  This helps you query InfluxDB for the statistics you want.
+  - `[prefix]` - applied to each measurement name. Useful if you want to limit the scope of your measurements to a specific service. You can specify a string, or an array of strings (recommended). Arrays will be joined by [prefixDelimiter] below.
+  - `[prefixDelimiter]` - Used to delimit measurement prefix arrays defined in [prefix] above. Defaults to `/`.
 
 ## Series
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Creates a new GoodInflux object where:
   - `[wreck]` - configuration object to pass into [`wreck`](https://github.com/hapijs/wreck#advanced). Defaults to `{ timeout: 60000, headers: {} }`. `content-type` is always "text/plain".
   - `[udpType]` - UDP type; defaults to `udp4`. Probably not necessary to change, but more documentation is available on the [NodeJS Dgram Documentation](https://nodejs.org/api/dgram.html#dgram_dgram_createsocket_type_callback)
   - `[metadata]` - arbitrary tags you would like to add to your InfluxDB stats.  This helps you query InfluxDB for the statistics you want.
-  - `[prefix]` - applied to each measurement name. Useful if you want to limit the scope of your measurements to a specific service. You can specify a string, or an array of strings (recommended). Arrays will be joined by [prefixDelimiter] below.
+  - `[prefix]` - applied to each measurement name. Useful if you want to limit the scope of your measurements to a specific service. You can specify a string, or an array of strings (recommended). Arrays will be joined by *prefixDelimiter* below. For example, using `prefix: ['my', 'awesome', 'service']` the `ops` measurement will be renamed to
+  `my/awesome/service/ops`
   - `[prefixDelimiter]` - Used to delimit measurement prefix arrays defined in [prefix] above. Defaults to `/`.
 
 ## Series

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Creates a new GoodInflux object where:
   - `[metadata]` - arbitrary tags you would like to add to your InfluxDB stats.  This helps you query InfluxDB for the statistics you want.
   - `[prefix]` - applied to each measurement name. Useful if you want to limit the scope of your measurements to a specific service. You can specify a string, or an array of strings (recommended). Arrays will be joined by *prefixDelimiter* below. For example, using `prefix: ['my', 'awesome', 'service']` the `ops` measurement will be renamed to
   `my/awesome/service/ops`
-  - `[prefixDelimiter]` - Used to delimit measurement prefix arrays defined in [prefix] above. Defaults to `/`.
+  - `[prefixDelimiter]` - Used to delimit measurement prefix arrays defined in *prefix* above. Defaults to `/`.
 
 ## Series
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const options = {
                     dataCenter: 'Banff'
                 },
                 prefix: ['my', 'awesome', 'service']
-        	}]
+            }]
         }]
     }
 };

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -38,15 +38,33 @@ const tags = (config, event) => {
         Object.keys(config.metadata).forEach((key) => {
             const value = config.metadata[key];
             if (value !== undefined && value !== null && value !== '') {
-                completeTags[key] = `${value}`
-                    .replace(',', '\\,')
-                    .replace('=', '\\=')
-                    .replace(' ', '\\ ');
+                completeTags[key] = formatTagKV(value);
             }
         });
     }
 
     return completeTags;
+};
+
+/**
+ * Format a measurement name. Commas and spaces must be escaped.
+ * @see https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_tutorial
+ */
+const formatMeasurement = (name) => {
+    return `${name}`
+        .replace(/,/g, '\\,')
+        .replace(/ /g, '\\ ');
+};
+
+/**
+ * Format a tag key or value. Commas, spaces, and equals signs must be escaped.
+ * @see https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_tutorial
+ */
+const formatTagKV = (value) => {
+    return `${value}`
+        .replace(/,/g, '\\,')
+        .replace(/=/g, '\\=')
+        .replace(/ /g, '\\ ');
 };
 
 const serialize = (obj) => {
@@ -58,6 +76,8 @@ const serialize = (obj) => {
 module.exports = {
     Int: influxInt,
     String: formatString,
+    Measurement: formatMeasurement,
+    TagKV: formatTagKV,
     tags,
     serialize
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Extracts the namespace from the configuration, used to 
+ * prefix all measurement names.
+ */
+const measurementPrefix = (config) => {
+
+    config = config || {};
+    const prefix = config.prefix;
+    let delimiter = config.prefixDelimiter;
+
+    let result = '';
+    if (Array.isArray(prefix)) {
+        if (typeof delimiter !== 'string') {
+            delimiter = '/';
+        }
+        result = `${prefix.join(delimiter)}${delimiter}`;
+    }
+    else if (typeof prefix === 'string') {
+        result = prefix;
+    }
+    return result;
+};
+
+module.exports = {
+    measurementPrefix
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,8 +1,7 @@
 'use strict';
 
 /**
- * Extracts the namespace from the configuration, used to 
- * prefix all measurement names.
+ * Extracts the measurement prefix from the configuration.
  */
 const measurementPrefix = (config) => {
 

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -10,6 +10,7 @@ const Querystring = require('querystring');
 const Url = require('url');
 const Hoek = require('hoek');
 const OpsFormatter = require('./ops-format');
+const Helpers = require('./helpers');
 
 const Formatters = require('./formatters');
 
@@ -138,11 +139,14 @@ module.exports.format = (event, config) => {
     // Field set
     const values = Formatters.serialize(getEventValues(event));
 
+    const prefix = Helpers.measurementPrefix(config);
+    const finalEventName = Formatters.Measurement(`${prefix}${eventName}`);
+
     let loadValues = [];
     if (eventName === 'ops') {
         loadValues = OpsFormatter.format(event,config);
     }
-    const eventValue = `${eventName},${tags} ${values} ${timestamp}000000`;
+    const eventValue = `${finalEventName},${tags} ${values} ${timestamp}000000`;
     // Timestamp in InfluxDB is in nanoseconds
     if (loadValues.length === 0) {
         return eventValue;

--- a/lib/ops-format.js
+++ b/lib/ops-format.js
@@ -2,6 +2,7 @@
 
 const Hoek = require('hoek');
 const Formatters = require('./formatters');
+const Helpers = require('./helpers');
 
 const opsRequests = (event) => {
     const requests = Hoek.reach(event, 'load.requests');
@@ -87,8 +88,12 @@ const opsFormatHelper = (eventName, timestamp, tags, eventValues, config) => {
             else {
                 finalTags = tags;
             }
+
+            const prefix = Helpers.measurementPrefix(config);
+            const finalEventName = Formatters.Measurement(`${prefix}${eventName}`);
+
             // Timestamp in InfluxDB is in nanoseconds
-            return `${eventName},${finalTags} ${fields} ${timestamp}000000`;
+            return `${finalEventName},${finalTags} ${fields} ${timestamp}000000`;
         });
         return finalEventValues;
     }

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+const Helpers = require('../lib/helpers');
+
+describe('measurementPrefix', () => {
+    it('should preserve raw strings', (done) => {
+        const config = {
+            prefix: 'my-awesome-service-'
+        };
+        const prefix = Helpers.measurementPrefix(config);
+
+        expect(prefix).to.equal('my-awesome-service-');
+        done();
+    });
+    it('should join string arrays with a / by default', (done) => {
+        const config = {
+            prefix: ['my', 'awesome', 'service']
+        };
+        const prefix = Helpers.measurementPrefix(config);
+
+        expect(prefix).to.equal('my/awesome/service/');
+        done();
+    });
+    it('should join string arrays with a specified delimiter', (done) => {
+        const config = {
+            prefix: ['my', 'awesome', 'service'],
+            prefixDelimiter: '/'
+        };
+        const prefix = Helpers.measurementPrefix(config);
+
+        expect(prefix).to.equal('my/awesome/service/');
+        done();
+    });
+    it('should return an empty string, given an empty config', (done) => {
+        const prefix = Helpers.measurementPrefix({});
+        expect(prefix).to.equal('');
+        done();
+    });
+    it('should return an empty string, given no config', (done) => {
+        const prefix = Helpers.measurementPrefix();
+        expect(prefix).to.equal('');
+        done();
+    });
+});

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -172,3 +172,34 @@ describe('Metadata', () => {
         done();
     });
 });
+
+describe('Measurement prefixes', () => {
+
+    const testEvent = {
+        event: 'log',
+        host: 'mytesthost',
+        timestamp: 1485996802647,
+        tags: ['info', 'request'],
+        data: 'Things are good',
+        pid: 1234
+    };
+
+    it('Are applied correctly', (done) => {
+        const configs = {
+            prefix: ['my', 'awesome', 'service']
+        };
+        const eventWithPrefix = 'my/awesome/service/log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
+        expect(LineProtocol.format(testEvent, configs)).to.equal(eventWithPrefix);
+        done();
+    });
+
+    it('Special characters are escaped', (done) => {
+        const configs = {
+            prefix: ['my', ' ', 'awesome', ',', 'service', ' '],
+            prefixDelimiter: ''
+        };
+        const eventWithSpecialCharsInPrefix = 'my\\ awesome\\,service\\ log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
+        expect(LineProtocol.format(testEvent, configs)).to.equal(eventWithSpecialCharsInPrefix);
+        done();
+    });
+});


### PR DESCRIPTION
Resolves #5 

This PR adds the ability to prefix all measurement names with a namespace, which is very useful for keeping metrics data separated in large service ecosystems.

For example, 
```
{
  prefix: ['my', 'service', 'namespace']
}
```

will scope all measurement names to the namespace `my/service/namespace`. So, for instance, the `ops` measurement will be rewritten as `my/service/namespace/ops`.

The prefix delimiter defaults to `/`, but can easily be overridden with the `prefixDelimiter` option:
```
{
  prefix: ['my', 'service', 'namespace'],
  prefixDelimiter: '_'
}
```
results in measurements like `my_service_namespace_ops`.

Raw strings can also be used:
```
{
  prefix: 'myPrefix_'
}
```

Measurement names are properly escaped as per the influx protocol.