### PR TITLE
Compatibility with hapi@17.x.x toolchain (WIP)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - 7
-  - 6
-  - 4
+  - 9
+  - 8

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # good-influx
 
 [InfluxDB](https://docs.influxdata.com/) broadcasting for Good process monitor, based on [good-http](https://github.com/hapijs/good-http).
-It can write to HTTP or UDP Telegraf endpoints.
+It can write to HTTP or UDP Telegraf endpoints. Requires at least Node.js v8 and hapi v17.
 
 ![Current Version](https://img.shields.io/npm/v/good-influx.svg)
 [![Build Status](https://travis-ci.org/fhemberger/good-influx.svg?branch=master)](https://travis-ci.org/fhemberger/good-influx)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-influx",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "repository": "git://github.com/fhemberger/good-influx",
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",
@@ -11,23 +11,23 @@
   "author": "Frederic Hemberger (https://frederic-hemberger.de/)",
   "license": "MIT",
   "dependencies": {
-    "fast-safe-stringify": "^1.1.13",
+    "fast-safe-stringify": "^1.2.1",
     "good-http": "^6.1.3",
     "good-udp": "4.1.x",
-    "hoek": "^4.1.1",
-    "wreck": "^12.2.0"
+    "hoek": "^5.0.2",
+    "wreck": "^14.0.2"
   },
   "devDependencies": {
-    "code": "^4.0.0",
-    "eslint": "^4.2.0",
-    "eslint-config-hapi": "^10.0.0",
+    "code": "^5.1.2",
+    "eslint": "^4.10.0",
+    "eslint-config-hapi": "^11.1.0",
     "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-hapi": "^4.0.0",
-    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-hapi": "^4.1.0",
+    "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
-    "lab": "^14.1.0"
+    "lab": "^15.1.2"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   }
 }

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -11,25 +11,25 @@ const expect = Code.expect;
 const Helpers = require('../lib/helpers');
 
 describe('measurementPrefix', () => {
-    it('should preserve raw strings', (done) => {
+    it('should preserve raw strings', () => {
         const config = {
             prefix: 'my-awesome-service-'
         };
         const prefix = Helpers.measurementPrefix(config);
 
         expect(prefix).to.equal('my-awesome-service-');
-        done();
     });
-    it('should join string arrays with a / by default', (done) => {
+
+    it('should join string arrays with a / by default', () => {
         const config = {
             prefix: ['my', 'awesome', 'service']
         };
         const prefix = Helpers.measurementPrefix(config);
 
         expect(prefix).to.equal('my/awesome/service/');
-        done();
     });
-    it('should join string arrays with a specified delimiter', (done) => {
+
+    it('should join string arrays with a specified delimiter', () => {
         const config = {
             prefix: ['my', 'awesome', 'service'],
             prefixDelimiter: '/'
@@ -37,16 +37,15 @@ describe('measurementPrefix', () => {
         const prefix = Helpers.measurementPrefix(config);
 
         expect(prefix).to.equal('my/awesome/service/');
-        done();
     });
-    it('should return an empty string, given an empty config', (done) => {
+
+    it('should return an empty string, given an empty config', () => {
         const prefix = Helpers.measurementPrefix({});
         expect(prefix).to.equal('');
-        done();
     });
-    it('should return an empty string, given no config', (done) => {
+
+    it('should return an empty string, given no config', () => {
         const prefix = Helpers.measurementPrefix();
         expect(prefix).to.equal('');
-        done();
     });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,7 +58,7 @@ const mocks = {
         return `${protocol}://${address.address}:${address.port}`;
     },
 
-    getHttpServer(expectedMsg, done) {
+    getHttpServer (expectedMsg) {
         let hitCount = 0;
         const server = Http.createServer((req, res) => {
             let data = '';
@@ -72,7 +72,7 @@ const mocks = {
 
                 res.end();
                 if (hitCount >= 2) {
-                    server.close(done);
+                    server.close();
                 }
             });
         });
@@ -80,7 +80,7 @@ const mocks = {
         return server;
     },
 
-    getUdpServer(expectedNumberOfEvents, expectedMsg, done) {
+    getUdpServer (expectedNumberOfEvents, expectedMsg) {
         let hitCount = 0;
         const server = Dgram.createSocket('udp4');
         server.on('message', (msg) => {
@@ -88,7 +88,7 @@ const mocks = {
             validateResponses(msg.toString(), expectedNumberOfEvents, expectedMsg);
 
             if (hitCount >= 2) {
-                server.close(done);
+                server.close();
             }
         });
         server.bind(9876, '127.0.0.1');
@@ -107,8 +107,8 @@ const Options = {
 
 describe('GoodInflux', () => {
     describe('HTTP URL =>', () => {
-        it('Sends events in a stream to HTTP server', (done) => {
-            const server = mocks.getHttpServer(msgWithMetadata, done);
+        it('Sends events in a stream to HTTP server', async () => {
+            const server = await mocks.getHttpServer(msgWithMetadata);
             const stream = mocks.readStream();
 
             server.listen(0, '127.0.0.1', () => {
@@ -125,8 +125,8 @@ describe('GoodInflux', () => {
     });
 
     describe('UDP URL =>', () => {
-        it('Threshold not set => Sends 5 events in a stream to UDP server', (done) => {
-            const server = mocks.getUdpServer(5, msgWithMetadata, done);
+        it('Threshold not set => Sends 5 events in a stream to UDP server', async () => {
+            const server = await mocks.getUdpServer(5, msgWithMetadata);
             const stream = mocks.readStream();
 
             server.on('listening', () => {
@@ -142,8 +142,8 @@ describe('GoodInflux', () => {
             });
         });
 
-        it('Threshold of 3 => Sends 3 events in a stream to UDP server', (done) => {
-            const server = mocks.getUdpServer(3, msgWithoutMetadata, done);
+        it('Threshold of 3 => Sends 3 events in a stream to UDP server', async () => {
+            const server = await mocks.getUdpServer(3, msgWithoutMetadata);
             const stream = mocks.readStream();
 
             server.on('listening', () => {
@@ -161,8 +161,8 @@ describe('GoodInflux', () => {
             });
         });
 
-        it('Threshold of 13 => Sends 5 events in a stream to UDP server', (done) => {
-            const server = mocks.getUdpServer(5, msgWithoutMetadata, done);
+        it('Threshold of 13 => Sends 5 events in a stream to UDP server', async () => {
+            const server = await mocks.getUdpServer(5, msgWithoutMetadata);
             const stream = mocks.readStream();
 
             server.on('listening', () => {
@@ -181,15 +181,14 @@ describe('GoodInflux', () => {
         });
     });
 
-    it('Unsupported protocol => throw error', (done) => {
+    it('Unsupported protocol => throw error', () => {
         expect(() => {
             return new GoodInflux('ftp://abcd:1234', {});
         }).to.throw(Error, 'Unsupported protocol ftp:. Supported protocols are udp, http or https');
-        done();
     });
 
-    it('Omit metadata when not defined', (done) => {
-        const server = mocks.getHttpServer(msgWithoutMetadata, done);
+    it('Omit metadata when not defined', async () => {
+        const server = await mocks.getHttpServer(msgWithoutMetadata);
         const stream = mocks.readStream();
 
         server.listen(0, '127.0.0.1', () => {
@@ -207,8 +206,8 @@ describe('GoodInflux', () => {
         });
     });
 
-    it('Omit metadata when empty', (done) => {
-        const server = mocks.getHttpServer(msgWithoutMetadata, done);
+    it('Omit metadata when empty', async () => {
+        const server = await mocks.getHttpServer(msgWithoutMetadata);
         const stream = mocks.readStream();
 
         server.listen(0, '127.0.0.1', () => {
@@ -227,8 +226,8 @@ describe('GoodInflux', () => {
         });
     });
 
-    it('Omit undefined metadata', (done) => {
-        const server = mocks.getHttpServer(msgWithMetadata, done);
+    it('Omit undefined metadata', async () => {
+        const server = await mocks.getHttpServer(msgWithMetadata);
         const stream = mocks.readStream();
 
         const opts = Hoek.clone(Options);

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -11,7 +11,7 @@ const it = lab.it;
 const expect = Code.expect;
 
 describe('log', () => {
-    it('Event log is formatted as expected', (done) => {
+    it('Event log is formatted as expected', () => {
         const testEvent = {
             event: 'log',
             host: 'mytesthost',
@@ -23,12 +23,11 @@ describe('log', () => {
         const formattedLogEvent = LineProtocol.format(testEvent, {});
         const expectedLogEvent = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 });
 
 describe('request', () => {
-    it('Event request is formatted as expected', (done) => {
+    it('Event request is formatted as expected', () => {
         const testEvent = {
             event: 'request',
             host: 'mytesthost',
@@ -43,13 +42,12 @@ describe('request', () => {
         const formattedLogEvent = LineProtocol.format(testEvent, {});
         const expectedLogEvent = 'request,host=mytesthost,pid=1234 data="userid=001",id="4321",method="POST",path="/hello",tags="request,blahblahblah" 1485996802647000000';
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 });
 
 
 describe('response', () => {
-    it('Event response is formatted as expected', (done) => {
+    it('Event response is formatted as expected', () => {
         const testEvent = {
             event: 'response',
             host: 'mytesthost',
@@ -75,12 +73,11 @@ describe('response', () => {
         const formattedLogEvent = LineProtocol.format(testEvent, {});
         const expectedLogEvent = 'response,host=mytesthost,pid=1234 httpVersion="1.1",id="1234",instance="mytesthost",labels="label001",method="GET",path="/hello",query="k1=v1&k2=v2",referer="referer",remoteAddress="127.0.0.1",responseTime=500i,statusCode=200i,userAgent="Chrome" 1485996802647000000';
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 });
 
 describe('error', () => {
-    it('Event error is formatted as expected', (done) => {
+    it('Event error is formatted as expected', () => {
         const testEvent = {
             event: 'error',
             host: 'mytesthost',
@@ -99,19 +96,17 @@ describe('error', () => {
         const formattedLogEvent = LineProtocol.format(testEvent, {});
         const expectedLogEvent = 'error,host=mytesthost,pid=1234 error.name="error1",error.message="this is an error msg",error.stack="stackoverflow",id="1234",url="/hello",method="GET",tags="error,crash" 1485996802647000000';
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 });
 
 describe('Unrecognized event', () => {
-    it('LineProtocol simply returns', (done) => {
+    it('LineProtocol simply returns', () => {
         const testEvent = {
             event: 'hello',
             host: 'mytesthost',
             timestamp: 1485996802647
         };
         expect(LineProtocol.format(testEvent, {})).to.equal(undefined);
-        done();
     });
 });
 
@@ -125,13 +120,12 @@ describe('Metadata', () => {
         pid: 1234
     };
 
-    it('No metadata set => Tags contain host and PID', (done) => {
+    it('No metadata set => Tags contain host and PID', () => {
         const logEventNoMetadata = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
         expect(LineProtocol.format(testEvent, {})).to.equal(logEventNoMetadata);
-        done();
     });
 
-    it('Metadata set => Contained in tags', (done) => {
+    it('Metadata set => Contained in tags', () => {
         const configs = {
             metadata: {
                 protocol: 'magic'
@@ -139,10 +133,9 @@ describe('Metadata', () => {
         };
         const logEventWithMetadata = 'log,host=mytesthost,pid=1234,protocol=magic data="Things are good",tags="info,request" 1485996802647000000';
         expect(LineProtocol.format(testEvent, configs)).to.equal(logEventWithMetadata);
-        done();
     });
 
-    it('Special characters properly escaped', (done) => {
+    it('Special characters properly escaped', () => {
         const configs = {
             metadata: {
                 'hometown': 'BikeCity,USA',
@@ -155,10 +148,9 @@ describe('Metadata', () => {
         const logEventSpecialChars = `log,${tagSet} data="Things are good",tags="info,request" 1485996802647000000`;
 
         expect(LineProtocol.format(testEvent, configs)).to.equal(logEventSpecialChars);
-        done();
     });
 
-    it('Null, undefined and empty string => no metadata added', (done) => {
+    it('Null, undefined and empty string => no metadata added', () => {
         const configs = {
             metadata: {
                 nullValue: null,
@@ -169,7 +161,6 @@ describe('Metadata', () => {
 
         const logEventNoMetadata = 'log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
         expect(LineProtocol.format(testEvent, configs)).to.equal(logEventNoMetadata);
-        done();
     });
 });
 
@@ -184,22 +175,20 @@ describe('Measurement prefixes', () => {
         pid: 1234
     };
 
-    it('Are applied correctly', (done) => {
+    it('Are applied correctly', () => {
         const configs = {
             prefix: ['my', 'awesome', 'service']
         };
         const eventWithPrefix = 'my/awesome/service/log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
         expect(LineProtocol.format(testEvent, configs)).to.equal(eventWithPrefix);
-        done();
     });
 
-    it('Special characters are escaped', (done) => {
+    it('Special characters are escaped', () => {
         const configs = {
             prefix: ['my', ' ', 'awesome', ',', 'service', ' '],
             prefixDelimiter: ''
         };
         const eventWithSpecialCharsInPrefix = 'my\\ awesome\\,service\\ log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000';
         expect(LineProtocol.format(testEvent, configs)).to.equal(eventWithSpecialCharsInPrefix);
-        done();
     });
 });

--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -72,22 +72,22 @@ const getExpectedMessage = (ports, metadata, responseTimesAvg, responseTimesMax)
 };
 
 describe('ops all events', () => {
-    it('One port => five events created', (done) => {
+    it('One port => five events created', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         const formattedEvent = LineProtocol.format(testEvent, {});
         expect(formattedEvent).to.equal(getExpectedMessage(['8080']));
-        done();
     });
-    it('Two ports => nine events created', (done) => {
+
+    it('Two ports => nine events created', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.requests['8081'] = testEvent.load.requests['8080'];
         testEvent.load.concurrents['8081'] = testEvent.load.concurrents['8080'];
         testEvent.load.responseTimes['8081'] = testEvent.load.responseTimes['8080'];
         const formattedEvent = LineProtocol.format(testEvent, {});
         expect(formattedEvent).to.equal(getExpectedMessage(['8080','8081']));
-        done();
     });
-    it('No ports reported => Only format the ops event', (done) => {
+
+    it('No ports reported => Only format the ops event', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.requests = {};
         testEvent.load.concurrents = {};
@@ -95,9 +95,9 @@ describe('ops all events', () => {
 
         const formattedEvent = LineProtocol.format(testEvent, {});
         expect(formattedEvent).to.equal(getExpectedMessage([]));
-        done();
     });
-    it('Metadata included as tags only', (done) => {
+
+    it('Metadata included as tags only', () => {
         const config = {
             metadata: {
                 serviceName: 'my-awesome-service'
@@ -107,25 +107,23 @@ describe('ops all events', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         const formattedEvent = LineProtocol.format(testEvent, config);
         expect(formattedEvent).to.equal(getExpectedMessage(['8080'], expectedMetadata));
-        done();
     });
 });
 
 describe('ops_responseTimes avg max', () => {
-    it('avg is null and max is string => avg and max shall be 0s', (done) => {
+    it('avg is null and max is string => avg and max shall be 0s', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.responseTimes['8080'].avg = null;
         testEvent.load.responseTimes['8080'].max = 'abc';
         const formattedEvent = LineProtocol.format(testEvent, {});
         expect(formattedEvent).to.equal(getExpectedMessage(['8080'],null,0,0));
-        done();
     });
-    it('avg and max are both numbers => avg and max shall be numbers', (done) => {
+
+    it('avg and max are both numbers => avg and max shall be numbers', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.responseTimes['8080'].avg = 123;
         testEvent.load.responseTimes['8080'].max = '456';
         const formattedEvent = LineProtocol.format(testEvent, {});
         expect(formattedEvent).to.equal(getExpectedMessage(['8080'],null,123,456));
-        done();
     });
 });


### PR DESCRIPTION
Update tests to be compatible with the new `lab` version and `hapi@17.x.x`

TODO: `mocks.getHttpServer` and `mocks.getUdpServer` need to be updated using `async`/`await`.

Refs:
- https://github.com/hapijs/hapi/issues/3658
- https://github.com/hapijs/good/issues/568

**EDIT:** `good` itself is not yet compatible with hapi 17 yet, waiting for a decision there. 