### PR TITLE
Flatten data when it's an object

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -6,7 +6,8 @@ const Stringify = require('fast-safe-stringify');
 const influxInt = (value) => {
     if (Number.isInteger(Number(value))) {
         return `${String(value)}i`;
-    } else if (!isNaN(value)) {
+    }
+    else if (!isNaN(value)) {
         return +value;
     }
 };
@@ -74,30 +75,31 @@ const serialize = (obj) => {
         .join(',');
 };
 
-function flatten(data, prefix = 'data') {
+const flatten = (data, prefix = 'data') => {
     if (data && typeof data === 'object' && !Array.isArray(data)) {
-        let returnVal = {}
-        Object.keys(data).forEach(key => {
-            let val = data[key]
-            returnVal = Object.assign(returnVal, flatten(val, `${prefix}.${key}`))
-        })
-        return returnVal
-    } else {
-        return {
-            [`${prefix}`]: formatVal(data)
-        }
+        let returnVal = {};
+        Object.keys(data).forEach((key) => {
+            const val = data[key];
+            returnVal = Object.assign(returnVal, flatten(val, `${prefix}.${key}`));
+        });
+        return returnVal;
     }
-}
+    return {
+        [`${prefix}`]: formatVal(data)
+    };
+};
 
-function formatVal(value) {
+const formatVal = (value) => {
     if (Array.isArray(value)) {
-        return formatString(value)
-    } else if (!isNaN(+value) && isFinite(value)) {
-        return influxInt(value)
-    } else if (value) {
-        return formatString(value)
+        return formatString(value);
     }
-}
+    else if (!isNaN(+value) && isFinite(value)) {
+        return influxInt(value);
+    }
+    else if (value) {
+        return formatString(value);
+    }
+};
 
 module.exports = {
     Int: influxInt,

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -6,8 +6,9 @@ const Stringify = require('fast-safe-stringify');
 const influxInt = (value) => {
     if (Number.isInteger(Number(value))) {
         return `${String(value)}i`;
+    } else if (!isNaN(value)) {
+        return +value;
     }
-    return value;
 };
 
 const formatString = (value) => {
@@ -73,9 +74,35 @@ const serialize = (obj) => {
         .join(',');
 };
 
+function flatten(data, prefix = 'data') {
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+        let returnVal = {}
+        Object.keys(data).forEach(key => {
+            let val = data[key]
+            returnVal = Object.assign(returnVal, flatten(val, `${prefix}.${key}`))
+        })
+        return returnVal
+    } else {
+        return {
+            [`${prefix}`]: formatVal(data)
+        }
+    }
+}
+
+function formatVal(value) {
+    if (Array.isArray(value)) {
+        return formatString(value)
+    } else if (!isNaN(+value) && isFinite(value)) {
+        return influxInt(value)
+    } else if (value) {
+        return formatString(value)
+    }
+}
+
 module.exports = {
     Int: influxInt,
     String: formatString,
+    Flatten: flatten,
     Measurement: formatMeasurement,
     TagKV: formatTagKV,
     tags,

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -26,11 +26,7 @@ internals.formatError = (error) => {
 
     if (error.isBoom) {
         result['error.statusCode'] = Formatters.Int(error.output.statusCode);
-
-        Object.keys(error.data).forEach((key) => {
-
-            result[`error.data.${key}`] = Formatters.String(error.data[key]);
-        });
+        result.error = Object.assign({}, Formatters.Flatten(error.data), result.error)
     }
 
     return result;
@@ -83,10 +79,9 @@ internals.values = {
             }
         }
 
-        return {
-            data: Formatters.String(event.data),
+        return Object.assign({}, Formatters.Flatten(event.data), {
             tags: Formatters.String(event.tags)
-        };
+        });
     },
     ops: (event) => {
 
@@ -122,13 +117,12 @@ internals.values = {
             );
         }
 
-        return {
-            data: Formatters.String(event.data),
+        return Object.assign({}, Formatters.Flatten(event.data), {
             id: Formatters.String(event.id),
             method: Formatters.String(event.method && event.method.toUpperCase()),
             path: Formatters.String(event.path),
             tags: Formatters.String(event.tags)
-        };
+        });
     },
     response: (event) => {
 

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -26,7 +26,7 @@ internals.formatError = (error) => {
 
     if (error.isBoom) {
         result['error.statusCode'] = Formatters.Int(error.output.statusCode);
-        result.error = Object.assign({}, Formatters.Flatten(error.data), result.error)
+        result.error = Object.assign({}, Formatters.Flatten(error.data), result.error);
     }
 
     return result;

--- a/test/formatters.test.js
+++ b/test/formatters.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+const Formatters = require('../lib/formatters');
+
+describe('Formatters - Flatten', () => {
+    it('flatten a nested object', (done) => {
+        const data = {
+            a: {
+                b: 'test'
+            },
+            c: 5,
+            d: 5.1,
+            e: ['test', 'array'],
+            f: 'string'
+        };
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData['data.a.b']).to.equal('\"test\"');
+        expect(flatData['data.c']).to.equal('5i');
+        expect(flatData['data.d']).to.equal(5.1);
+        expect(flatData['data.e']).to.equal('\"test,array\"');
+        expect(flatData['data.f']).to.equal('\"string\"');
+        done();
+    });
+
+    it('flatten a string', (done) => {
+        const data = 'string';
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData.data).to.equal('\"string\"');
+        done();
+    });
+
+    it('flatten an array', (done) => {
+        const data = ['test', 'array'];
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData.data).to.equal('\"test,array\"');
+        done();
+    });
+
+    it('flatten a number', (done) => {
+        const data = 5;
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData.data).to.equal('5i');
+        done();
+    });
+
+    it('flatten a float', (done) => {
+        const data = 5.1;
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData.data).to.equal(5.1);
+        done();
+    });
+});


### PR DESCRIPTION
This PR will set it up so that if the `data` field is an object, it automatically gets flattened into a set of fields. This should allow for more verbose logging of data.