### PR TITLE
Allow field tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Creates a new GoodInflux object where:
   `my/awesome/service/ops`
   - `[prefixDelimiter]` - Used to delimit measurement prefix arrays defined in *prefix* above. Defaults to `/`.
   - `[customLogFormatters]` - This options allows you to report specific log events based on tag (Note the first matching tag in `event.tags` will be used, it's better to have specific tags in practice). Ordinarily, log events are sent as a string. However, you may want to extract a custom data field and send it to Influx in a more searchable format. For example:
+  - `[fieldTags]` - This option takes an array of strings. When logging data it will look for those fields in the data values processed and then add them to the `tags` if they are.
 ```json
 {
   "event": "log",

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -6,7 +6,8 @@ const Stringify = require('fast-safe-stringify');
 const influxInt = (value) => {
     if (Number.isInteger(Number(value))) {
         return `${String(value)}i`;
-    } else if (!isNaN(value)) {
+    }
+    else if (!isNaN(value)) {
         return +value;
     }
 };
@@ -74,30 +75,31 @@ const serialize = (obj) => {
         .join(',');
 };
 
-function flatten(data, prefix = 'data') {
+const flatten = (data, prefix = 'data') => {
     if (data && typeof data === 'object' && !Array.isArray(data)) {
-        let returnVal = {}
-        Object.keys(data).forEach(key => {
-            let val = data[key]
-            returnVal = Object.assign(returnVal, flatten(val, `${prefix}.${key}`))
-        })
-        return returnVal
-    } else {
-        return {
-            [`${prefix}`]: formatVal(data)
-        }
+        let returnVal = {};
+        Object.keys(data).forEach((key) => {
+            const val = data[key];
+            returnVal = Object.assign(returnVal, flatten(val, `${prefix}.${key}`));
+        });
+        return returnVal;
     }
-}
+    return {
+        [`${prefix}`]: formatVal(data)
+    };
+};
 
-function formatVal(value) {
+const formatVal = (value) => {
     if (Array.isArray(value)) {
-        return formatString(value)
-    } else if (!isNaN(+value) && isFinite(value)) {
-        return influxInt(value)
-    } else if (value) {
-        return formatString(value)
+        return formatString(value);
     }
-}
+    else if (!isNaN(+value) && isFinite(value)) {
+        return influxInt(value);
+    }
+    else if (value) {
+        return formatString(value);
+    }
+};
 
 module.exports = {
     Int: influxInt,

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -29,7 +29,7 @@ const formatString = (value) => {
 // If metadata is configured, add it to the tags.
 // Special characters are escaped as defined in InfluxDB documentation:
 // https://docs.influxdata.com/influxdb/v1.3/write_protocols/line_protocol_tutorial/
-const tags = (config, event) => {
+const tags = (config, event, values) => {
 
     const completeTags = {
         host: event.host || Os.hostname(),
@@ -43,6 +43,14 @@ const tags = (config, event) => {
                 completeTags[key] = formatTagKV(value);
             }
         });
+    }
+
+    if (values && Array.isArray(config.fieldTags)) {
+        config.fieldTags.forEach(field => {
+            if (values[field]) {
+                completeTags[field] = formatTagKV(values[field]).replace(/"/g, '')
+            }
+        })
     }
 
     return completeTags;

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -46,11 +46,11 @@ const tags = (config, event, values) => {
     }
 
     if (values && Array.isArray(config.fieldTags)) {
-        config.fieldTags.forEach(field => {
+        config.fieldTags.forEach((field) => {
             if (values[field]) {
-                completeTags[field] = formatTagKV(values[field]).replace(/"/g, '')
+                completeTags[field] = formatTagKV(values[field]).replace(/"/g, '');
             }
-        })
+        });
     }
 
     return completeTags;

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -6,8 +6,9 @@ const Stringify = require('fast-safe-stringify');
 const influxInt = (value) => {
     if (Number.isInteger(Number(value))) {
         return `${String(value)}i`;
+    } else if (!isNaN(value)) {
+        return +value;
     }
-    return value;
 };
 
 const formatString = (value) => {
@@ -73,9 +74,35 @@ const serialize = (obj) => {
         .join(',');
 };
 
+function flatten(data, prefix = 'data') {
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+        let returnVal = {}
+        Object.keys(data).forEach(key => {
+            let val = data[key]
+            returnVal = Object.assign(returnVal, flatten(val, `${prefix}.${key}`))
+        })
+        return returnVal
+    } else {
+        return {
+            [`${prefix}`]: formatVal(data)
+        }
+    }
+}
+
+function formatVal(value) {
+    if (Array.isArray(value)) {
+        return formatString(value)
+    } else if (!isNaN(+value) && isFinite(value)) {
+        return influxInt(value)
+    } else if (value) {
+        return formatString(value)
+    }
+}
+
 module.exports = {
     Int: influxInt,
     String: formatString,
+    Flatten: flatten,
     Measurement: formatMeasurement,
     TagKV: formatTagKV,
     tags,

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -153,7 +153,7 @@ module.exports.format = (event, config) => {
     }
 
     // Field set
-    const eventValues = getEventValues(event, config)
+    const eventValues = getEventValues(event, config);
     const values = Formatters.serialize(eventValues);
 
     // Tag set

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -152,11 +152,12 @@ module.exports.format = (event, config) => {
         return;
     }
 
-    // Tag set
-    const tags = Formatters.serialize(Formatters.tags(config, event));
-
     // Field set
-    const values = Formatters.serialize(getEventValues(event, config));
+    const eventValues = getEventValues(event, config)
+    const values = Formatters.serialize(eventValues);
+
+    // Tag set
+    const tags = Formatters.serialize(Formatters.tags(config, event, eventValues));
 
     const prefix = Helpers.measurementPrefix(config);
     const finalEventName = Formatters.Measurement(`${prefix}${eventName}`);

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -26,11 +26,7 @@ internals.formatError = (error) => {
 
     if (error.isBoom) {
         result['error.statusCode'] = Formatters.Int(error.output.statusCode);
-
-        Object.keys(error.data).forEach((key) => {
-
-            result[`error.data.${key}`] = Formatters.String(error.data[key]);
-        });
+        result.error = Object.assign({}, Formatters.Flatten(error.data), result.error)
     }
 
     return result;
@@ -83,10 +79,9 @@ internals.values = {
             }
         }
 
-        return {
-            data: Formatters.String(event.data),
+        return Object.assign({}, Formatters.Flatten(event.data), {
             tags: Formatters.String(event.tags)
-        };
+        });
     },
     ops: (event) => {
 
@@ -122,13 +117,12 @@ internals.values = {
             );
         }
 
-        return {
-            data: Formatters.String(event.data),
+        return Object.assign({}, Formatters.Flatten(event.data), {
             id: Formatters.String(event.id),
             method: Formatters.String(event.method && event.method.toUpperCase()),
             path: Formatters.String(event.path),
             tags: Formatters.String(event.tags)
-        };
+        });
     },
     response: (event) => {
 

--- a/lib/line-protocol.js
+++ b/lib/line-protocol.js
@@ -26,7 +26,7 @@ internals.formatError = (error) => {
 
     if (error.isBoom) {
         result['error.statusCode'] = Formatters.Int(error.output.statusCode);
-        result.error = Object.assign({}, Formatters.Flatten(error.data), result.error)
+        result.error = Object.assign({}, Formatters.Flatten(error.data), result.error);
     }
 
     return result;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "eslint-plugin-hapi": "^4.0.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "lab": "^14.1.0"
+    "lab": "^14.1.0",
+    "sinon": "^5.0.10"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/test/formatters.test.js
+++ b/test/formatters.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const Code = require('code');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+const Formatters = require('../lib/formatters');
+
+describe('Formatters - Flatten', () => {
+    it('flatten a nested object', (done) => {
+        const data = {
+            a: {
+                b: 'test'
+            },
+            c: 5,
+            d: 5.1,
+            e: ['test', 'array'],
+            f: 'string'
+        };
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData['data.a.b']).to.equal('\"test\"');
+        expect(flatData['data.c']).to.equal('5i');
+        expect(flatData['data.d']).to.equal(5.1);
+        expect(flatData['data.e']).to.equal('\"test,array\"');
+        expect(flatData['data.f']).to.equal('\"string\"');
+        done();
+    });
+
+    it('flatten a string', (done) => {
+        const data = 'string';
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData.data).to.equal('\"string\"');
+        done();
+    });
+
+    it('flatten an array', (done) => {
+        const data = ['test', 'array'];
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData.data).to.equal('\"test,array\"');
+        done();
+    });
+
+    it('flatten a number', (done) => {
+        const data = 5;
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData.data).to.equal('5i');
+        done();
+    });
+
+    it('flatten a float', (done) => {
+        const data = 5.1;
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData.data).to.equal(5.1);
+        done();
+    });
+});

--- a/test/formatters.test.js
+++ b/test/formatters.test.js
@@ -2,10 +2,14 @@
 
 const Code = require('code');
 const Lab = require('lab');
+const Sinon = require('sinon');
+const Os = require('os');
 const lab = exports.lab = Lab.script();
 
 const describe = lab.describe;
 const it = lab.it;
+const beforeEach = lab.beforeEach;
+const afterEach = lab.afterEach;
 const expect = Code.expect;
 
 const Formatters = require('../lib/formatters');
@@ -60,6 +64,86 @@ describe('Formatters - Flatten', () => {
         const flatData = Formatters.Flatten(data);
 
         expect(flatData.data).to.equal(5.1);
+        done();
+    });
+});
+
+describe('Formatters - tags', () => {
+    let sandbox;
+
+    beforeEach((done) => {
+        sandbox = Sinon.createSandbox();
+        sandbox.stub(Os, 'hostname').returns('test');
+        done();
+    });
+
+    afterEach((done) => {
+        sandbox.restore();
+        done();
+    });
+
+    it('formats tags with no config', (done) => {
+        const config = {};
+        const event = {
+            pid: 1
+        };
+        const values = {};
+
+        const tags = Formatters.tags(config, event, values);
+        expect(tags).to.equal({
+            host: 'test',
+            pid: 1
+        });
+
+        done();
+    });
+
+    it('formats tags with metadata', (done) => {
+        const config = {
+            metadata: {
+                a: 'test',
+                b: undefined,
+                c: null,
+                d: ''
+            }
+        };
+        const event = {
+            host: 'host',
+            pid: 1
+        };
+        const values = {};
+
+        const tags = Formatters.tags(config, event, values);
+        expect(tags).to.equal({
+            host: 'host',
+            pid: 1,
+            a: 'test'
+        });
+
+        done();
+    });
+
+    it('formats tags with field tags', (done) => {
+        const config = {
+            fieldTags: ['a', 'b', 'c']
+        };
+        const event = {
+            host: 'host',
+            pid: 1
+        };
+        const values = {
+            a: 'test',
+            b: '"test"'
+        };
+
+        const tags = Formatters.tags(config, event, values);
+        expect(tags).to.equal({
+            host: 'host',
+            pid: 1,
+            a: 'test',
+            b: 'test'
+        });
+
         done();
     });
 });


### PR DESCRIPTION
This PR depends on #40 to be merged first. It allows for specifying a list of fields to be used as tags (when present). This allows a user to set up a field in influx as a tag which can then be grouped on.