### PR TITLE
Correctly handle objects with circular reference(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Object items allow you to take things with unknown or arbitrary data and flatten
 
 *NOTE: You should still make an attempt to know what your data looks like before using this formatter. Influx only allows one type per field, and once it is set, and lines which attempt to place a different type in that field will just not be logged at all.*
 
+*NOTE: Objects with circular references are automatically truncated*
+
 - `[type]` - In this case, you must set type to `object`.
 - `[value]` - The base path to the object you want to flatten.
 - `[keyPrefix]` - Allows you to set a prefix for all values that are flattened.

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -52,7 +52,7 @@ const serialize = (obj) => {
         .join(',');
 };
 
-const flatten = (data, prefix = 'data', stack = []) => {
+const _flatten = (data, prefix = 'data', stack = []) => {
     if (stack.includes(data)) {
         return {
             [`${prefix}`]: formatVal('...omitted (circular reference detected)...')
@@ -65,7 +65,7 @@ const flatten = (data, prefix = 'data', stack = []) => {
         Object.keys(data).forEach((key) => {
             const val = data[key];
             const newPrefix = (prefix ? prefix + '.' : '') + key;
-            returnVal = Object.assign(returnVal, flatten(val, newPrefix, stack));
+            returnVal = Object.assign(returnVal, _flatten(val, newPrefix, stack));
         });
         stack.pop();
         return returnVal;
@@ -79,6 +79,8 @@ const flatten = (data, prefix = 'data', stack = []) => {
         [`${prefix}`]: formatVal(data)
     };
 };
+
+const flatten = (data, prefix) => _flatten(data, prefix);
 
 const formatVal = (value) => {
     if (Array.isArray(value)) {

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -52,14 +52,22 @@ const serialize = (obj) => {
         .join(',');
 };
 
-const flatten = (data, prefix = 'data') => {
+const flatten = (data, prefix = 'data', stack = []) => {
+    if (stack.includes(data)) {
+        return {
+            [`${prefix}`]: formatVal('...omitted (circular reference detected)...')
+        };
+    }
+
     if (data && typeof data === 'object' && !Array.isArray(data)) {
         let returnVal = {};
+        stack.push(data);
         Object.keys(data).forEach((key) => {
             const val = data[key];
             const newPrefix = (prefix ? prefix + '.' : '') + key;
-            returnVal = Object.assign(returnVal, flatten(val, newPrefix));
+            returnVal = Object.assign(returnVal, flatten(val, newPrefix, stack));
         });
+        stack.pop();
         return returnVal;
     }
 

--- a/test/formatters.test.js
+++ b/test/formatters.test.js
@@ -153,4 +153,21 @@ describe('Formatters - Flatten', () => {
         expect(flatData['data.self']).to.equal('\"...omitted (circular reference detected)...\"');
         done();
     });
+
+    it('flatten a complex object with circular reference', (done) => {
+        const data = {
+            a: 'test',
+            b: {
+                c: 'test',
+                d: {}
+            }
+        };
+        data.b.d.circular = data;
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData['data.a']).to.equal('\"test\"');
+        expect(flatData['data.b.c']).to.equal('\"test\"');
+        expect(flatData['data.b.d.circular']).to.equal('\"...omitted (circular reference detected)...\"');
+        done();
+    });
 });

--- a/test/formatters.test.js
+++ b/test/formatters.test.js
@@ -141,4 +141,16 @@ describe('Formatters - Flatten', () => {
         expect(flatData.data).to.be.undefined();
         done();
     });
+
+    it('flatten an object with circular reference', (done) => {
+        const data = {
+            a: 'test'
+        };
+        data.self = data;
+        const flatData = Formatters.Flatten(data);
+
+        expect(flatData['data.a']).to.equal('\"test\"');
+        expect(flatData['data.self']).to.equal('\"...omitted (circular reference detected)...\"');
+        done();
+    });
 });


### PR DESCRIPTION
# Issue

When passed an object with a circular reference, `Flatten` would infinitely loop until memory exhaustion/stack overflow.

# Fix

Flatten will detect circular references and bail out.  We incur some memory overhead to maintain a stack of "seen" objects.