### PR TITLE
Update dependencies

### DIFF
--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -81,7 +81,8 @@ class GoodInfluxHttp extends Stream.Writable {
         // Prevent this from user tampering
         if (wreckOptions.headers){
             wreckOptions.headers['content-type'] = 'text/plain';
-        } else {
+        }
+        else {
             wreckOptions.headers = { 'content-type': 'text/plain' };
         }
         Wreck.request('post', this._endpoint, wreckOptions).then((req) => {

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -79,8 +79,8 @@ class GoodInfluxHttp extends Stream.Writable {
         Hoek.merge(wreckOptions, this._settings.wreck, { nullOverride: false });
 
         // Prevent this from user tampering
-        if(wreckOptions.headers){
-            wreckOptions.headers['content-type'] = 'text/plain'
+        if (wreckOptions.headers){
+            wreckOptions.headers['content-type'] = 'text/plain';
         } else {
             wreckOptions.headers = { 'content-type': 'text/plain' };
         }

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -70,8 +70,7 @@ class GoodInfluxHttp extends Stream.Writable {
         Hoek.merge(wreckOptions, this._settings.wreck, { nullOverride: false });
 
         // Prevent this from user tampering
-        wreckOptions.headers ? wreckOptions.headers['content-type'] = 'text/plain'
-            : wreckOptions.headers = { 'content-type': 'text/plain' };
+        wreckOptions.headers['content-type'] = 'text/plain';
         Wreck.request('post', this._endpoint, wreckOptions).then((req) => {
             return callback(null, req);
         });

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -70,7 +70,8 @@ class GoodInfluxHttp extends Stream.Writable {
         Hoek.merge(wreckOptions, this._settings.wreck, { nullOverride: false });
 
         // Prevent this from user tampering
-        wreckOptions.headers = { 'content-type': 'text/plain' };
+        wreckOptions.headers ? wreckOptions.headers['content-type'] = 'text/plain'
+            : wreckOptions.headers = { 'content-type': 'text/plain' };
         Wreck.request('post', this._endpoint, wreckOptions).then((req) => {
             return callback(null, req);
         });

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Hoek = require('@hapi/hoek');
-const GoodHttp = require('good-http');
+const Stream = require('stream');
 const Wreck = require('@hapi/wreck');
 const LineProtocol = require('./line-protocol.js');
 
@@ -11,13 +11,52 @@ const internals = {
     }
 };
 
-class GoodInfluxHttp extends GoodHttp {
+class GoodInfluxHttp extends Stream.Writable {
     constructor(endpoint, config, schemas) {
-        super(endpoint, config, schemas);
+        config = config || {};
+        const settings = Object.assign({}, internals.defaults, config);
+
+        if (settings.errorThreshold === null) {
+            settings.errorThreshold = -Infinity;
+        }
+
+        super({ objectMode: true, decodeStrings: false });
+        this._settings = settings;
+        this._endpoint = endpoint;
+        this._data = [];
+        this._failureCount = 0;
+
+        // Standard users
+        this.once('finish', () => {
+
+            this._sendMessages();
+        });
         this._settings.schema = 'good-influx';
         this.config = Hoek.applyToDefaults(internals.defaults, config);
         this.schemas = schemas;
     }
+    _write(data, encoding, callback) {
+
+        this._data.push(data);
+        if (this._data.length >= this._settings.threshold) {
+            this._sendMessages((err) => {
+
+                if (err && this._failureCount < this._settings.errorThreshold) {
+                    this._failureCount++;
+                    return callback();
+                }
+
+                this._data = [];
+                this._failureCount = 0;
+
+                return callback(this._settings.errorThreshold !== -Infinity && err);
+            });
+        }
+        else {
+            setImmediate(callback);
+        }
+    }
+
     _sendMessages(callback) {
         let lineData = [];
         this._data.forEach((event) => {
@@ -28,11 +67,13 @@ class GoodInfluxHttp extends GoodHttp {
             payload: lineData.join('\n')
         };
 
-        Hoek.merge(wreckOptions, this._settings.wreck, false);
+        Hoek.merge(wreckOptions, this._settings.wreck, { nullOverride: false });
 
         // Prevent this from user tampering
-        wreckOptions.headers['content-type'] = 'text/plain';
-        Wreck.request('post', this._endpoint, wreckOptions, callback);
+        wreckOptions.headers = { 'content-type': 'text/plain' };
+        Wreck.request('post', this._endpoint, wreckOptions).then((req) => {
+            return callback(null, req);
+        });
     }
 }
 

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -70,7 +70,8 @@ class GoodInfluxHttp extends Stream.Writable {
         Hoek.merge(wreckOptions, this._settings.wreck, { nullOverride: false });
 
         // Prevent this from user tampering
-        wreckOptions.headers['content-type'] = 'text/plain';
+        wreckOptions.headers ? wreckOptions.headers['content-type'] = 'text/plain'
+            : wreckOptions.headers = { 'content-type': 'text/plain' };
         Wreck.request('post', this._endpoint, wreckOptions).then((req) => {
             return callback(null, req);
         });

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -79,8 +79,11 @@ class GoodInfluxHttp extends Stream.Writable {
         Hoek.merge(wreckOptions, this._settings.wreck, { nullOverride: false });
 
         // Prevent this from user tampering
-        wreckOptions.headers ? wreckOptions.headers['content-type'] = 'text/plain'
-            : wreckOptions.headers = { 'content-type': 'text/plain' };
+        if(wreckOptions.headers){
+            wreckOptions.headers['content-type'] = 'text/plain'
+        } else {
+            wreckOptions.headers = { 'content-type': 'text/plain' };
+        }
         Wreck.request('post', this._endpoint, wreckOptions).then((req) => {
             return callback(null, req);
         });

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const GoodHttp = require('good-http');
-const Wreck = require('wreck');
+const Wreck = require('@hapi/wreck');
 const LineProtocol = require('./line-protocol.js');
 
 const internals = {

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -3,10 +3,19 @@
 const Hoek = require('@hapi/hoek');
 const Stream = require('stream');
 const Wreck = require('@hapi/wreck');
+const Os = require('os');
 const LineProtocol = require('./line-protocol.js');
 
 const internals = {
     defaults: {
+        threshold: 20,
+        errorThreshold: 0,
+        schema: 'good-influx',
+        wreck: {
+            timeout: 60000,
+            headers: {}
+        },
+        host: Os.hostname(),
         metadata: false
     }
 };
@@ -31,7 +40,6 @@ class GoodInfluxHttp extends Stream.Writable {
 
             this._sendMessages();
         });
-        this._settings.schema = 'good-influx';
         this.config = Hoek.applyToDefaults(internals.defaults, config);
         this.schemas = schemas;
     }

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -22,6 +22,7 @@ const internals = {
 
 class GoodInfluxHttp extends Stream.Writable {
     constructor(endpoint, config, schemas) {
+        super({ objectMode: true, decodeStrings: false });
         config = config || {};
         const settings = Object.assign({}, internals.defaults, config);
 
@@ -29,7 +30,6 @@ class GoodInfluxHttp extends Stream.Writable {
             settings.errorThreshold = -Infinity;
         }
 
-        super({ objectMode: true, decodeStrings: false });
         this._settings = settings;
         this._endpoint = endpoint;
         this._data = [];
@@ -43,6 +43,7 @@ class GoodInfluxHttp extends Stream.Writable {
         this.config = Hoek.applyToDefaults(internals.defaults, config);
         this.schemas = schemas;
     }
+
     _write(data, encoding, callback) {
 
         this._data.push(data);

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -1,25 +1,61 @@
 'use strict';
 
-const GoodUdp = require('good-udp');
+const Dgram = require('dgram');
+const Stream = require('stream');
+const Os = require('os');
+const Url = require('url');
+
 const Hoek = require('@hapi/hoek');
 const LineProtocol = require('./line-protocol.js');
 
 const internals = {
     defaults: {
+        threshold: 20,
+        schema: 'good-udp',
+        udpType: 'udp4',
+        host: Os.hostname(),
         metadata: false
     }
 };
 
-class GoodInfluxUdp extends GoodUdp {
+class GoodInfluxUdp extends Stream.Writable {
     constructor(endpoint, config, schemas) {
         // Limit threshold for UDP protocol to avoid transmission errors
         if (isNaN(config.threshold) || config.threshold > 5) {
             config.threshold = 5;
         }
-        super(endpoint, config);
+        config = config || {};
+        const settings = Object.assign({}, internals.defaults, config);
+
+        super({ objectMode: true, decodeStrings: false });
+        this._settings = settings;
+        this._endpoint = Url.parse(endpoint);
+        this._data = [];
+        this._udpClient = Dgram.createSocket(settings.udpType);
+
+        // Standard users
+        this.once('finish', () => {
+
+            this._sendMessages();
+        });
         this._settings.schema = 'good-influx';
         this.config = Hoek.applyToDefaults(internals.defaults, config);
         this.schemas = schemas;
+    }
+    _write(data, encoding, callback) {
+
+        this._data.push(data);
+        if (this._data.length >= this._settings.threshold) {
+            this._sendMessages((err) => {
+
+                // always clear the data so we don't buffer this forever if there is ever a failed POST
+                this._data = [];
+                return callback(err);
+            });
+        }
+        else {
+            setImmediate(callback);
+        }
     }
 
     _sendMessages(callback) {

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -20,14 +20,16 @@ const internals = {
 
 class GoodInfluxUdp extends Stream.Writable {
     constructor(endpoint, config, schemas) {
+        super({ objectMode: true, decodeStrings: false });
+
         // Limit threshold for UDP protocol to avoid transmission errors
         if (isNaN(config.threshold) || config.threshold > 5) {
             config.threshold = 5;
         }
+
         config = config || {};
         const settings = Object.assign({}, internals.defaults, config);
 
-        super({ objectMode: true, decodeStrings: false });
         this._settings = settings;
         this._endpoint = Url.parse(endpoint);
         this._data = [];
@@ -41,6 +43,7 @@ class GoodInfluxUdp extends Stream.Writable {
         this.config = Hoek.applyToDefaults(internals.defaults, config);
         this.schemas = schemas;
     }
+
     _write(data, encoding, callback) {
 
         this._data.push(data);

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -11,7 +11,7 @@ const LineProtocol = require('./line-protocol.js');
 const internals = {
     defaults: {
         threshold: 20,
-        schema: 'good-udp',
+        schema: 'good-influx',
         udpType: 'udp4',
         host: Os.hostname(),
         metadata: false
@@ -38,7 +38,6 @@ class GoodInfluxUdp extends Stream.Writable {
 
             this._sendMessages();
         });
-        this._settings.schema = 'good-influx';
         this.config = Hoek.applyToDefaults(internals.defaults, config);
         this.schemas = schemas;
     }

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const GoodUdp = require('good-udp');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const LineProtocol = require('./line-protocol.js');
 
 const internals = {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.10"
   },
   "devDependencies": {
-    "@types/node": "^13.1.7",
+    "@types/node": "^8.10.59",
     "code": "^4.0.0",
     "eslint": "^4.2.0",
     "eslint-config-hapi": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "fast-safe-stringify": "^2.0.2",
     "good-http": "^6.1.3",
     "good-udp": "4.1.x",
-    "hoek": "^4.1.1",
+    "@hapi/hoek": "^9.0.2",
     "lodash": "^4.17.10",
-    "wreck": "^12.2.0"
+    "@hapi/wreck": "^17.0.0"
   },
   "devDependencies": {
     "code": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "lodash": "^4.17.10"
   },
   "devDependencies": {
-    "code": "^4.0.0",
     "@types/node": "^13.1.7",
+    "code": "^4.0.0",
     "eslint": "^4.2.0",
     "eslint-config-hapi": "^11.1.0",
     "eslint-config-standard": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,14 @@
   "author": "Frederic Hemberger (https://frederic-hemberger.de/)",
   "license": "MIT",
   "dependencies": {
-    "fast-safe-stringify": "^2.0.2",
-    "good-http": "^6.1.3",
-    "good-udp": "4.1.x",
     "@hapi/hoek": "^9.0.2",
-    "lodash": "^4.17.10",
-    "@hapi/wreck": "^17.0.0"
+    "@hapi/wreck": "^17.0.0",
+    "fast-safe-stringify": "^2.0.2",
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "code": "^4.0.0",
+    "@types/node": "^13.1.7",
     "eslint": "^4.2.0",
     "eslint-config-hapi": "^11.1.0",
     "eslint-config-standard": "^10.2.1",


### PR DESCRIPTION
removes good-http and good-udp. They're both deprecated and we only use simple code from them. I've moved the associated code to this codebase and updated the HAPI dependencies.

All Tests pass, exactly 95% coverage.
