### PR TITLE
Node 16 upgrades

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,6 @@ jobs:
           name: Install NPM Dependencies
           command: npm install
       - run:
-          name: Build Publish Assets
-          command: npm run build
-      - run:
           name: Publish to NPM
           command: npm publish --tag next --access public
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.9.4
+    - image: circleci/node:16
 
 version: 2
 jobs:
@@ -36,6 +36,23 @@ jobs:
           name: Publish to NPM
           command: npm publish --access public
 
+  publish_next:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Generate .npmrc File
+          command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
+      - run:
+          name: Install NPM Dependencies
+          command: npm install
+      - run:
+          name: Build Publish Assets
+          command: npm run build
+      - run:
+          name: Publish to NPM
+          command: npm publish --tag next --access public
+
 workflows:
   version: 2
   build_test:
@@ -51,5 +68,14 @@ workflows:
             filters:
               tags:
                 only: /^(v){1}[0-9]+(\.[0-9]+){2}$/
+              branches:
+                ignore: /.*/
+
+        - publish_next:
+            requires:
+              - test
+            filters:
+              tags:
+                only: /^(v){1}[0-9]+(\.[0-9]+){2}(-)[0-9]+$/
               branches:
                 ignore: /.*/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,8 @@
 {
-  "extends": "eslint-config-hapi",
+  "extends": "plugin:@hapi/recommended",
   "rules": {
-    "hapi/hapi-scope-start": "off"
+    "@hapi/scope-start": "off",
+    "key-spacing": "off",
+    "padding-line-between-statements": "off"
   }
 }

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -38,7 +38,7 @@ class GoodInfluxHttp extends Stream.Writable {
         // Standard users
         this.once('finish', () => {
 
-            this._sendMessages();
+            this._sendMessages(() => { /* no-op */ });
         });
         this.config = Hoek.applyToDefaults(internals.defaults, config);
         this.schemas = schemas;
@@ -87,6 +87,8 @@ class GoodInfluxHttp extends Stream.Writable {
         }
         Wreck.request('post', this._endpoint, wreckOptions).then((req) => {
             return callback(null, req);
+        }).catch((err) => {
+            return callback(err)
         });
     }
 }

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -88,7 +88,7 @@ class GoodInfluxHttp extends Stream.Writable {
         Wreck.request('post', this._endpoint, wreckOptions).then((req) => {
             return callback(null, req);
         }).catch((err) => {
-            return callback(err)
+            return callback(err);
         });
     }
 }

--- a/lib/good-influx-http.js
+++ b/lib/good-influx-http.js
@@ -79,7 +79,7 @@ class GoodInfluxHttp extends Stream.Writable {
         Hoek.merge(wreckOptions, this._settings.wreck, { nullOverride: false });
 
         // Prevent this from user tampering
-        if (wreckOptions.headers){
+        if (wreckOptions.headers) {
             wreckOptions.headers['content-type'] = 'text/plain';
         }
         else {

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -38,7 +38,7 @@ class GoodInfluxUdp extends Stream.Writable {
         // Standard users
         this.once('finish', () => {
 
-            this._sendMessages();
+            this._sendMessages(() => { /* no-op */ });
         });
         this.config = Hoek.applyToDefaults(internals.defaults, config);
         this.schemas = schemas;

--- a/lib/good-influx-udp.js
+++ b/lib/good-influx-udp.js
@@ -67,7 +67,7 @@ class GoodInfluxUdp extends Stream.Writable {
             lineData = lineData.concat(lines);
         });
 
-        const payload = new Buffer(lineData.join('\n'));
+        const payload = Buffer.from(lineData.join('\n'));
 
         // Prevent this from user tampering
         this._udpClient.send(payload, 0, payload.length, this._endpoint.port, this._endpoint.hostname, callback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creditkarma/good-influx",
-  "version": "5.0.1-0",
+  "version": "5.0.1-1",
   "repository": "https://github.com/creditkarma/good-influx",
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -5,28 +5,27 @@
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",
   "scripts": {
-    "test": "lab -m 5000 -t 94 -v -La code",
-    "test-cov-html": "lab -m 5000 -r html -o coverage.html -La code"
+    "test": "lab -m 5000 -t 93 -v -La @hapi/code",
+    "test-cov-html": "lab -m 5000 -r html -o coverage.html -La @hapi/code"
   },
   "author": "Frederic Hemberger (https://frederic-hemberger.de/)",
   "license": "MIT",
   "dependencies": {
-    "@hapi/hoek": "^9.0.2",
-    "@hapi/wreck": "^17.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/wreck": "^18.0.0",
     "fast-safe-stringify": "^2.0.2",
     "lodash": "^4.17.10"
   },
   "devDependencies": {
-    "@types/node": "^8.10.59",
-    "code": "^4.0.0",
-    "eslint": "^4.2.0",
-    "eslint-config-hapi": "^11.1.0",
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/lab": "^25.0.1",
+    "@types/node": "^16.11.34",
+    "eslint": "^8.16.0",
     "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-hapi": "^4.0.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "lab": "^14.1.0",
-    "sinon": "^5.0.10"
+    "sinon": "^14.0.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creditkarma/good-influx",
-  "version": "5.0.1-2",
+  "version": "5.0.1-3",
   "repository": "https://github.com/creditkarma/good-influx",
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creditkarma/good-influx",
-  "version": "5.0.1-3",
+  "version": "5.0.1-4",
   "repository": "https://github.com/creditkarma/good-influx",
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creditkarma/good-influx",
-  "version": "5.0.1-4",
+  "version": "5.0.0",
   "repository": "https://github.com/creditkarma/good-influx",
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creditkarma/good-influx",
-  "version": "5.0.0",
+  "version": "5.0.1-0",
   "repository": "https://github.com/creditkarma/good-influx",
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creditkarma/good-influx",
-  "version": "5.0.1-1",
+  "version": "5.0.1-2",
   "repository": "https://github.com/creditkarma/good-influx",
   "description": "InfluxDB broadcasting for Good process monitor",
   "main": "lib/index.js",

--- a/test/formatters.test.js
+++ b/test/formatters.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Code = require('code');
-const Lab = require('lab');
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
 const lab = exports.lab = Lab.script();
 
 const describe = lab.describe;
@@ -11,58 +11,49 @@ const expect = Code.expect;
 const Formatters = require('../lib/formatters');
 
 describe('Formatters - Int', () => {
-    it('formats an integer', (done) => {
+    it('formats an integer', () => {
         expect(Formatters.Int(1)).to.equal('1i');
-        done();
     });
 
-    it('formats a float', (done) => {
+    it('formats a float', () => {
         expect(Formatters.Int(1.1)).to.equal('1i');
-        done();
     });
 
-    it('formats a string', (done) => {
+    it('formats a string', () => {
         expect(Formatters.Int('1')).to.equal('1i');
-        done();
     });
 
-    it('does not format a non-number', (done) => {
+    it('does not format a non-number', () => {
         expect(Formatters.Int('a')).to.equal(undefined);
-        done();
     });
 });
 
 describe('Formatters - String', () => {
-    it('formats a basic string', (done) => {
+    it('formats a basic string', () => {
         expect(Formatters.String('test')).to.equal('"test"');
-        done();
     });
 
-    it('formats a object', (done) => {
+    it('formats a object', () => {
         expect(Formatters.String({ a: 'test' })).to.equal('"{\\"a\\":\\"test\\"}"');
-        done();
     });
 
-    it('formats an array', (done) => {
+    it('formats an array', () => {
         expect(Formatters.String(['a','b'])).to.equal('"a,b"');
-        done();
     });
 
-    it('formats a string with newlines', (done) => {
+    it('formats a string with newlines', () => {
         expect(Formatters.String('test\r\ntest')).to.equal('"test\\ntest"');
-        done();
     });
 });
 
 describe('Formatters - Measurement', () => {
-    it('formats a measurement', (done) => {
+    it('formats a measurement', () => {
         expect(Formatters.Measurement('t,e st')).to.equal('t\\,e\\ st');
-        done();
     });
 });
 
 describe('Formatters - Flatten', () => {
-    it('flatten a nested object', (done) => {
+    it('flatten a nested object', () => {
         const data = {
             a: {
                 b: 'test'
@@ -81,68 +72,60 @@ describe('Formatters - Flatten', () => {
         expect(flatData['data.e']).to.equal('\"test,array\"');
         expect(flatData['data.f']).to.equal('\"string\"');
         expect(flatData['data.g']).to.not.exist();
-        done();
     });
 
-    it('flatten a nested object no prefix', (done) => {
+    it('flatten a nested object no prefix', () => {
         const data = {
             a: 'test'
         };
         const flatData = Formatters.Flatten(data, '');
 
         expect(flatData.a).to.equal('\"test\"');
-        done();
     });
 
-    it('flatten a string', (done) => {
+    it('flatten a string', () => {
         const data = 'string';
         const flatData = Formatters.Flatten(data);
 
         expect(flatData.data).to.equal('\"string\"');
-        done();
     });
 
-    it('flatten an array', (done) => {
+    it('flatten an array', () => {
         const data = ['test', 'array'];
         const flatData = Formatters.Flatten(data);
 
         expect(flatData.data).to.equal('\"test,array\"');
-        done();
     });
 
-    it('flatten a number', (done) => {
+    it('flatten a number', () => {
         const data = 5;
         const flatData = Formatters.Flatten(data);
 
         expect(flatData.data).to.equal('5i');
-        done();
     });
 
-    it('flatten a float', (done) => {
+    it('flatten a float', () => {
         const data = 5.1;
         const flatData = Formatters.Flatten(data);
 
         expect(flatData.data).to.equal(5.1);
-        done();
     });
 
-    it('flatten undefined', (done) => {
+    it('flatten undefined', () => {
         const data = undefined;
         const flatData = Formatters.Flatten(data);
 
         expect(flatData.data).to.be.undefined();
-        done();
     });
 
-    it('flatten null', (done) => {
+    it('flatten null', () => {
         const data = null;
         const flatData = Formatters.Flatten(data);
 
         expect(flatData.data).to.be.undefined();
-        done();
     });
 
-    it('flatten an object with circular reference', (done) => {
+    it('flatten an object with circular reference', () => {
         const data = {
             a: 'test'
         };
@@ -151,10 +134,9 @@ describe('Formatters - Flatten', () => {
 
         expect(flatData['data.a']).to.equal('\"test\"');
         expect(flatData['data.self']).to.equal('\"...omitted (circular reference detected)...\"');
-        done();
     });
 
-    it('flatten a complex object with circular reference', (done) => {
+    it('flatten a complex object with circular reference', () => {
         const data = {
             a: 'test',
             b: {
@@ -168,6 +150,5 @@ describe('Formatters - Flatten', () => {
         expect(flatData['data.a']).to.equal('\"test\"');
         expect(flatData['data.b.c']).to.equal('\"test\"');
         expect(flatData['data.b.d.circular']).to.equal('\"...omitted (circular reference detected)...\"');
-        done();
     });
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Code = require('code');
-const Lab = require('lab');
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
 const lab = exports.lab = Lab.script();
 
 const describe = lab.describe;
@@ -11,25 +11,23 @@ const expect = Code.expect;
 const Helpers = require('../lib/helpers');
 
 describe('measurementPrefix', () => {
-    it('should preserve raw strings', (done) => {
+    it('should preserve raw strings', () => {
         const config = {
             prefix: 'my-awesome-service-'
         };
         const prefix = Helpers.measurementPrefix(config);
 
         expect(prefix).to.equal('my-awesome-service-');
-        done();
     });
-    it('should join string arrays with a / by default', (done) => {
+    it('should join string arrays with a / by default', () => {
         const config = {
             prefix: ['my', 'awesome', 'service']
         };
         const prefix = Helpers.measurementPrefix(config);
 
         expect(prefix).to.equal('my/awesome/service/');
-        done();
     });
-    it('should join string arrays with a specified delimiter', (done) => {
+    it('should join string arrays with a specified delimiter', () => {
         const config = {
             prefix: ['my', 'awesome', 'service'],
             prefixDelimiter: '/'
@@ -37,16 +35,13 @@ describe('measurementPrefix', () => {
         const prefix = Helpers.measurementPrefix(config);
 
         expect(prefix).to.equal('my/awesome/service/');
-        done();
     });
-    it('should return an empty string, given an empty config', (done) => {
+    it('should return an empty string, given an empty config', () => {
         const prefix = Helpers.measurementPrefix({});
         expect(prefix).to.equal('');
-        done();
     });
-    it('should return an empty string, given no config', (done) => {
+    it('should return an empty string, given no config', () => {
         const prefix = Helpers.measurementPrefix();
         expect(prefix).to.equal('');
-        done();
     });
 });

--- a/test/line-protocol.test.js
+++ b/test/line-protocol.test.js
@@ -3,8 +3,8 @@
 const LineProtocol = require('../lib/line-protocol');
 const Schemas = require('../schemas');
 
-const Code = require('code');
-const Lab = require('lab');
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
 const lab = exports.lab = Lab.script();
 
 const describe = lab.describe;
@@ -12,7 +12,7 @@ const it = lab.it;
 const expect = Code.expect;
 
 describe('log', () => {
-    it('Event log is formatted as expected', (done) => {
+    it('Event log is formatted as expected', () => {
         const testEvent = {
             event: 'log',
             host: 'mytesthost',
@@ -24,12 +24,11 @@ describe('log', () => {
         const formattedLogEvent = LineProtocol.format(testEvent, {}, Schemas);
         const expectedLogEvent = ['log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000'];
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 });
 
 describe('request', () => {
-    it('Event request is formatted as expected', (done) => {
+    it('Event request is formatted as expected', () => {
         const testEvent = {
             event: 'request',
             host: 'mytesthost',
@@ -44,13 +43,12 @@ describe('request', () => {
         const formattedLogEvent = LineProtocol.format(testEvent, {}, Schemas);
         const expectedLogEvent = ['request,host=mytesthost,pid=1234 data="userid=001",id="4321",method="POST",path="/hello",tags="request,blahblahblah" 1485996802647000000'];
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 });
 
 
 describe('response', () => {
-    it('Event response is formatted as expected', (done) => {
+    it('Event response is formatted as expected', () => {
         const testEvent = {
             event: 'response',
             host: 'mytesthost',
@@ -76,12 +74,11 @@ describe('response', () => {
         const formattedLogEvent = LineProtocol.format(testEvent, {}, Schemas);
         const expectedLogEvent = ['response,host=mytesthost,pid=1234 httpVersion="1.1",id="1234",instance="mytesthost",labels="label001",method="GET",path="/hello",query="k1=v1&k2=v2",referer="referer",remoteAddress="127.0.0.1",responseTime=500i,statusCode=200i,userAgent="Chrome" 1485996802647000000'];
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 });
 
 describe('error', () => {
-    it('Event error is formatted as expected', (done) => {
+    it('Event error is formatted as expected', () => {
         const testEvent = {
             event: 'error',
             host: 'mytesthost',
@@ -100,19 +97,17 @@ describe('error', () => {
         const formattedLogEvent = LineProtocol.format(testEvent, {}, Schemas);
         const expectedLogEvent = ['error,host=mytesthost,pid=1234 error.name="error1",error.message="this is an error msg",error.stack="stackoverflow",id="1234",url="/hello",method="GET",tags="error,crash" 1485996802647000000'];
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 });
 
 describe('Unrecognized event', () => {
-    it('LineProtocol simply returns', (done) => {
+    it('LineProtocol simply returns', () => {
         const testEvent = {
             event: 'hello',
             host: 'mytesthost',
             timestamp: 1485996802647
         };
         expect(LineProtocol.format(testEvent, {}, Schemas)).to.equal([]);
-        done();
     });
 });
 
@@ -127,28 +122,26 @@ describe('Measurement prefixes', () => {
         pid: 1234
     };
 
-    it('Are applied correctly', (done) => {
+    it('Are applied correctly', () => {
         const configs = {
             prefix: ['my', 'awesome', 'service']
         };
         const eventWithPrefix = ['my/awesome/service/log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000'];
         expect(LineProtocol.format(testEvent, configs, Schemas)).to.equal(eventWithPrefix);
-        done();
     });
 
-    it('Special characters are escaped', (done) => {
+    it('Special characters are escaped', () => {
         const configs = {
             prefix: ['my', ' ', 'awesome', ',', 'service', ' '],
             prefixDelimiter: ''
         };
         const eventWithSpecialCharsInPrefix = ['my\\ awesome\\,service\\ log,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000'];
         expect(LineProtocol.format(testEvent, configs, Schemas)).to.equal(eventWithSpecialCharsInPrefix);
-        done();
     });
 });
 
 describe('configs', () => {
-    it('Event log is formatted as expected with default tags', (done) => {
+    it('Event log is formatted as expected with default tags', () => {
         const testEvent = {
             event: 'log',
             host: 'mytesthost',
@@ -164,10 +157,9 @@ describe('configs', () => {
         }, Schemas);
         const expectedLogEvent = ['log,test=test,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000'];
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 
-    it('Event log is formatted as expected with default fields', (done) => {
+    it('Event log is formatted as expected with default fields', () => {
         const testEvent = {
             event: 'log',
             host: 'mytesthost',
@@ -183,10 +175,9 @@ describe('configs', () => {
         }, Schemas);
         const expectedLogEvent = ['log,host=mytesthost,pid=1234 test="test",data="Things are good",tags="info,request" 1485996802647000000'];
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 
-    it('Event log is formatted as expected with event name redirection', (done) => {
+    it('Event log is formatted as expected with event name redirection', () => {
         const testEvent = {
             event: 'log',
             host: 'mytesthost',
@@ -206,10 +197,9 @@ describe('configs', () => {
         });
         const expectedLogEvent = ['test,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000'];
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 
-    it('Event log is formatted as expected with event name function redirection', (done) => {
+    it('Event log is formatted as expected with event name function redirection', () => {
         const testEvent = {
             event: 'log',
             host: 'mytesthost',
@@ -229,6 +219,5 @@ describe('configs', () => {
         });
         const expectedLogEvent = ['test,host=mytesthost,pid=1234 data="Things are good",tags="info,request" 1485996802647000000'];
         expect(formattedLogEvent).to.equal(expectedLogEvent);
-        done();
     });
 });

--- a/test/ops.test.js
+++ b/test/ops.test.js
@@ -3,8 +3,8 @@
 const LineProtocol = require('../lib/line-protocol');
 const Schemas = require('../schemas');
 
-const Code = require('code');
-const Lab = require('lab');
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
 const lab = exports.lab = Lab.script();
 
 const describe = lab.describe;
@@ -74,22 +74,20 @@ const getExpectedMessage = (ports, metadata, responseTimesAvg, responseTimesMax)
 };
 
 describe('ops all events', () => {
-    it('One port => five events created', (done) => {
+    it('One port => five events created', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         const formattedEvent = LineProtocol.format(testEvent, {}, Schemas);
         expect(formattedEvent).to.equal(getExpectedMessage(['8080']));
-        done();
     });
-    it('Two ports => nine events created', (done) => {
+    it('Two ports => nine events created', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.requests['8081'] = testEvent.load.requests['8080'];
         testEvent.load.concurrents['8081'] = testEvent.load.concurrents['8080'];
         testEvent.load.responseTimes['8081'] = testEvent.load.responseTimes['8080'];
         const formattedEvent = LineProtocol.format(testEvent, {}, Schemas);
         expect(formattedEvent).to.equal(getExpectedMessage(['8080','8081']));
-        done();
     });
-    it('No ports reported => Only format the ops event', (done) => {
+    it('No ports reported => Only format the ops event', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.requests = {};
         testEvent.load.concurrents = {};
@@ -97,9 +95,8 @@ describe('ops all events', () => {
 
         const formattedEvent = LineProtocol.format(testEvent, {}, Schemas);
         expect(formattedEvent).to.equal(getExpectedMessage([]));
-        done();
     });
-    it('Undefined conurrrents reported => handles as empty object', (done) => {
+    it('Undefined conurrrents reported => handles as empty object', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.requests = {};
         testEvent.load.concurrents = undefined;
@@ -107,25 +104,22 @@ describe('ops all events', () => {
 
         const formattedEvent = LineProtocol.format(testEvent, {}, Schemas);
         expect(formattedEvent).to.equal(getExpectedMessage([]));
-        done();
     });
 });
 
 describe('ops_responseTimes avg max', () => {
-    it('avg is null and max is string => avg and max shall be 0s', (done) => {
+    it('avg is null and max is string => avg and max shall be 0s', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.responseTimes['8080'].avg = null;
         testEvent.load.responseTimes['8080'].max = 'abc';
         const formattedEvent = LineProtocol.format(testEvent, {}, Schemas);
         expect(formattedEvent).to.equal(getExpectedMessage(['8080'],null,0,0));
-        done();
     });
-    it('avg and max are both numbers => avg and max shall be numbers', (done) => {
+    it('avg and max are both numbers => avg and max shall be numbers', () => {
         const testEvent = JSON.parse(testOpsEventBase);
         testEvent.load.responseTimes['8080'].avg = 123;
         testEvent.load.responseTimes['8080'].max = '456';
         const formattedEvent = LineProtocol.format(testEvent, {}, Schemas);
         expect(formattedEvent).to.equal(getExpectedMessage(['8080'],null,123,456));
-        done();
     });
 });


### PR DESCRIPTION
Also upgrades typescript to 4.6, and hapi libraries to latest.
Fixes a bug where errors weren't caught and passed through the callback.
Fixes a bug where finish didn't pass in a callback.

Also adds a prerelease workflow